### PR TITLE
fix: clean up cache-timer (#9) — drop --watch, tail-read transcript, add tests

### DIFF
--- a/src/claude_statusbar/cli.py
+++ b/src/claude_statusbar/cli.py
@@ -196,11 +196,6 @@ Integration:
         help="Show detailed breakdown of usage data and limits",
     )
     parser.add_argument(
-        "--watch",
-        action="store_true",
-        help="Live refresh mode: re-render status bar every 5 seconds",
-    )
-    parser.add_argument(
         "--plan",
         type=str,
         help=(
@@ -326,41 +321,16 @@ Integration:
         # Pull in the heavy render path only now (after we've definitely
         # decided to render — subcommands have already returned by here).
         from .core import main as statusbar_main
-
-        if args.watch:
-            # Watch mode: re-render every 5 seconds
-            import time
-            print("📡 Watch mode: Press Ctrl+C to stop", file=sys.stderr)
-            try:
-                while True:
-                    # Clear line and re-render
-                    sys.stdout.write("\r\033[K")
-                    sys.stdout.flush()
-                    statusbar_main(
-                        json_output=json_output,
-                        reset_hour=reset_hour,
-                        use_color=use_color,
-                        detail=args.detail,
-                        warning_threshold=warning_threshold,
-                        critical_threshold=critical_threshold,
-                        style_override=args.style,
-                        theme_override=args.theme,
-                    )
-                    time.sleep(5)
-            except KeyboardInterrupt:
-                print("\n✓ Watch mode stopped", file=sys.stderr)
-                return 0
-        else:
-            statusbar_main(
-                json_output=json_output,
-                reset_hour=reset_hour,
-                use_color=use_color,
-                detail=args.detail,
-                warning_threshold=warning_threshold,
-                critical_threshold=critical_threshold,
-                style_override=args.style,
-                theme_override=args.theme,
-            )
+        statusbar_main(
+            json_output=json_output,
+            reset_hour=reset_hour,
+            use_color=use_color,
+            detail=args.detail,
+            warning_threshold=warning_threshold,
+            critical_threshold=critical_threshold,
+            style_override=args.style,
+            theme_override=args.theme,
+        )
         return 0
     except KeyboardInterrupt:
         return 130

--- a/src/claude_statusbar/core.py
+++ b/src/claude_statusbar/core.py
@@ -842,36 +842,82 @@ def format_number(num: float) -> str:
     return f"{num:.0f}"
 
 
+def _last_assistant_age(transcript_path: str) -> Optional[float]:
+    """Find the last assistant entry's age in seconds by tail-reading the JSONL.
+
+    Reads the file from the end in 32KB chunks instead of slurping the whole
+    transcript — these files can be many MB and the status bar runs on every
+    Claude Code render.
+    """
+    chunk_size = 32 * 1024
+    try:
+        with open(transcript_path, "rb") as f:
+            f.seek(0, 2)
+            file_size = f.tell()
+            if file_size == 0:
+                return None
+            buf = b""
+            pos = file_size
+            # Walk backwards collecting chunks until we find an assistant entry
+            # or exhaust the file.
+            while pos > 0:
+                read = min(chunk_size, pos)
+                pos -= read
+                f.seek(pos)
+                buf = f.read(read) + buf
+                # Split into lines; drop the leading partial line unless we've
+                # already reached the start of the file.
+                lines = buf.split(b"\n")
+                if pos > 0:
+                    buf = lines[0]
+                    candidates = lines[1:]
+                else:
+                    buf = b""
+                    candidates = lines
+                for raw in reversed(candidates):
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        entry = json.loads(raw)
+                    except (ValueError, json.JSONDecodeError):
+                        continue
+                    if entry.get("type") != "assistant":
+                        continue
+                    ts_str = entry.get("timestamp", "")
+                    if not ts_str:
+                        continue
+                    if ts_str.endswith("Z"):
+                        ts_str = ts_str[:-1] + "+00:00"
+                    try:
+                        last_ts = datetime.fromisoformat(ts_str)
+                    except ValueError:
+                        continue
+                    return (datetime.now(timezone.utc) - last_ts).total_seconds()
+    except OSError:
+        return None
+    return None
+
+
 def get_cache_age_text() -> str:
     """Return cache age: 'Xm Ys ago' if <5m, else 'COLD'."""
     cache_file = Path.home() / ".cache" / "claude-statusbar" / "last_stdin.json"
     CACHE_TTL = 5 * 60  # 300 seconds
 
+    age_s: Optional[float] = None
     try:
         raw = json.loads(cache_file.read_text(encoding="utf-8"))
-        tp = raw.get("transcript_path", "")
-        if tp:
-            # Scan transcript rückwärts nach letztem assistant-Entry
-            try:
-                lines = open(tp, encoding="utf-8").readlines()
-                for line in reversed(lines):
-                    entry = json.loads(line.strip())
-                    if entry.get("type") == "assistant":
-                        ts_str = entry.get("timestamp", "")
-                        if ts_str.endswith("Z"):
-                            ts_str = ts_str[:-1] + "+00:00"
-                        last_ts = datetime.fromisoformat(ts_str)
-                        age_s = (datetime.now(timezone.utc) - last_ts).total_seconds()
-                        break
-                else:
-                    # Kein assistant-Entry gefunden, fallback zu mtime
-                    age_s = datetime.now(timezone.utc).timestamp() - cache_file.stat().st_mtime
-            except (OSError, json.JSONDecodeError, ValueError):
-                age_s = datetime.now(timezone.utc).timestamp() - cache_file.stat().st_mtime
-        else:
-            age_s = datetime.now(timezone.utc).timestamp() - cache_file.stat().st_mtime
     except (OSError, json.JSONDecodeError, ValueError, FileNotFoundError):
         return ""
+
+    tp = raw.get("transcript_path", "")
+    if tp:
+        age_s = _last_assistant_age(tp)
+    if age_s is None:
+        try:
+            age_s = datetime.now(timezone.utc).timestamp() - cache_file.stat().st_mtime
+        except OSError:
+            return ""
 
     if age_s > CACHE_TTL:
         return "COLD"

--- a/tests/test_cache_age.py
+++ b/tests/test_cache_age.py
@@ -1,0 +1,145 @@
+"""Tests for the cache-age widget (get_cache_age_text + _last_assistant_age)."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from claude_statusbar import core
+
+
+def _write_jsonl(path: Path, entries):
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+
+
+def _stub_cache(monkeypatch, tmp_path: Path, transcript_path: str):
+    cache = tmp_path / "last_stdin.json"
+    cache.write_text(json.dumps({"transcript_path": transcript_path}), encoding="utf-8")
+
+    class _FakeHome:
+        def __truediv__(self, _other):
+            class _Joiner:
+                def __init__(self, base):
+                    self._p = base
+
+                def __truediv__(self, more):
+                    self._p = self._p / more
+                    return self
+
+                def read_text(self, **kw):
+                    return self._p.read_text(**kw)
+
+                def stat(self):
+                    return self._p.stat()
+
+            return _Joiner(tmp_path)
+
+    monkeypatch.setattr(core.Path, "home", classmethod(lambda cls: _FakeHome()))
+    return cache
+
+
+def test_last_assistant_age_finds_most_recent(tmp_path: Path):
+    transcript = tmp_path / "t.jsonl"
+    now = datetime.now(timezone.utc)
+    _write_jsonl(transcript, [
+        {"type": "user", "timestamp": (now - timedelta(seconds=600)).isoformat()},
+        {"type": "assistant", "timestamp": (now - timedelta(seconds=300)).isoformat()},
+        {"type": "user", "timestamp": (now - timedelta(seconds=120)).isoformat()},
+        {"type": "assistant", "timestamp": (now - timedelta(seconds=30)).isoformat()},
+    ])
+    age = core._last_assistant_age(str(transcript))
+    assert age is not None
+    assert 25 <= age <= 60
+
+
+def test_last_assistant_age_returns_none_when_no_assistant(tmp_path: Path):
+    transcript = tmp_path / "t.jsonl"
+    now = datetime.now(timezone.utc)
+    _write_jsonl(transcript, [
+        {"type": "user", "timestamp": now.isoformat()},
+    ])
+    assert core._last_assistant_age(str(transcript)) is None
+
+
+def test_last_assistant_age_handles_z_suffix(tmp_path: Path):
+    transcript = tmp_path / "t.jsonl"
+    now = datetime.now(timezone.utc)
+    ts = (now - timedelta(seconds=10)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    _write_jsonl(transcript, [{"type": "assistant", "timestamp": ts}])
+    age = core._last_assistant_age(str(transcript))
+    assert age is not None
+    assert 0 <= age <= 30
+
+
+def test_last_assistant_age_skips_malformed_lines(tmp_path: Path):
+    transcript = tmp_path / "t.jsonl"
+    now = datetime.now(timezone.utc)
+    transcript.write_text(
+        "not-json\n"
+        + json.dumps({"type": "assistant", "timestamp": (now - timedelta(seconds=5)).isoformat()})
+        + "\n"
+        + "also-not-json\n",
+        encoding="utf-8",
+    )
+    age = core._last_assistant_age(str(transcript))
+    assert age is not None
+    assert 0 <= age <= 30
+
+
+def test_last_assistant_age_works_across_chunk_boundary(tmp_path: Path, monkeypatch):
+    """The reverse-tail reader splits the file into chunks; assistant entries
+    should still be findable when split across two reads."""
+    monkeypatch.setattr(core, "_last_assistant_age", core._last_assistant_age)
+    transcript = tmp_path / "t.jsonl"
+    now = datetime.now(timezone.utc)
+    # Pad with bulky user entries so the assistant entry is past the first
+    # 32KB chunk boundary (counting from the end).
+    padding = [
+        {"type": "user", "text": "x" * 2000, "timestamp": now.isoformat()}
+        for _ in range(40)
+    ]
+    entries = [
+        {"type": "assistant", "timestamp": (now - timedelta(seconds=15)).isoformat()},
+    ] + padding
+    _write_jsonl(transcript, entries)
+    age = core._last_assistant_age(str(transcript))
+    assert age is not None
+    assert 0 <= age <= 60
+
+
+def test_last_assistant_age_returns_none_on_missing_file(tmp_path: Path):
+    assert core._last_assistant_age(str(tmp_path / "nope.jsonl")) is None
+
+
+def test_get_cache_age_text_cold(tmp_path: Path, monkeypatch):
+    transcript = tmp_path / "t.jsonl"
+    old = datetime.now(timezone.utc) - timedelta(seconds=400)
+    _write_jsonl(transcript, [{"type": "assistant", "timestamp": old.isoformat()}])
+    monkeypatch.setattr(core.Path, "home", classmethod(lambda cls: tmp_path.parent))
+    cache_dir = tmp_path.parent / ".cache" / "claude-statusbar"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / "last_stdin.json").write_text(
+        json.dumps({"transcript_path": str(transcript)}), encoding="utf-8"
+    )
+    assert core.get_cache_age_text() == "COLD"
+
+
+def test_get_cache_age_text_warm_minutes(tmp_path: Path, monkeypatch):
+    transcript = tmp_path / "t.jsonl"
+    ts = datetime.now(timezone.utc) - timedelta(seconds=130)
+    _write_jsonl(transcript, [{"type": "assistant", "timestamp": ts.isoformat()}])
+    monkeypatch.setattr(core.Path, "home", classmethod(lambda cls: tmp_path.parent))
+    cache_dir = tmp_path.parent / ".cache" / "claude-statusbar"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / "last_stdin.json").write_text(
+        json.dumps({"transcript_path": str(transcript)}), encoding="utf-8"
+    )
+    out = core.get_cache_age_text()
+    assert out.endswith(" ago")
+    assert out.startswith("2m")
+
+
+def test_get_cache_age_text_returns_empty_when_no_cache(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(core.Path, "home", classmethod(lambda cls: tmp_path))
+    assert core.get_cache_age_text() == ""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -175,3 +175,16 @@ def test_show_cost_persists(tmp_path: Path):
     assert cfg_mod.load_config(p).show_cost is True
     cfg_mod.set_value("show_cost", "false", p)
     assert cfg_mod.load_config(p).show_cost is False
+
+
+def test_show_cache_age_default_false(tmp_path: Path):
+    cfg = cfg_mod.load_config(tmp_path / "missing.json")
+    assert cfg.show_cache_age is False
+
+
+def test_show_cache_age_persists(tmp_path: Path):
+    p = tmp_path / "cfg.json"
+    cfg_mod.set_value("show_cache_age", "true", p)
+    assert cfg_mod.load_config(p).show_cache_age is True
+    cfg_mod.set_value("show_cache_age", "false", p)
+    assert cfg_mod.load_config(p).show_cache_age is False


### PR DESCRIPTION
Follow-up cleanup for #9.

## Changes
- **Drop `--watch` CLI mode** — unrelated to the cache-timer feature, and the statusline is invoked on demand by Claude Code (not run as a daemon).
- **Rewrite `get_cache_age_text()`**:
  - Reverse-tail JSONL reader in 32KB chunks instead of `readlines()` (transcripts can be many MB; statusline runs on every render).
  - Use `with open(...)` — fixes the file-handle leak.
  - Translate the German comments to English.
- **Tests** (`tests/test_cache_age.py`):
  - `_last_assistant_age` covers: most-recent wins, no-assistant returns None, Z-suffix timestamps, malformed lines skipped, chunk-boundary case, missing file.
  - `get_cache_age_text` covers: COLD path, warm-minutes formatting, empty when cache missing.
  - `tests/test_config.py` adds `show_cache_age` default + persistence.

## Test plan
- [x] `PYTHONPATH=src python3 -m pytest -q` — 190 passed
- [x] `python3 -m py_compile` clean