### PR TITLE
fix: cache segment — explicit 'cache' label + color isolation in classic

### DIFF
--- a/src/claude_statusbar/core.py
+++ b/src/claude_statusbar/core.py
@@ -939,8 +939,8 @@ def get_cache_age_text() -> str:
     mins = int(age_s) // 60
     secs = int(age_s) % 60
     if mins > 0:
-        return f"{mins}m{secs:02d}s ago"
-    return f"{secs}s ago"
+        return f"{mins}m{secs:02d}s"
+    return f"{secs}s"
 
 
 def main(json_output: bool = False,

--- a/src/claude_statusbar/styles.py
+++ b/src/claude_statusbar/styles.py
@@ -95,8 +95,8 @@ def render_capsule(
 
     if cache_age_text:
         is_cold = cache_age_text == "COLD"
-        bg = theme.s_hot if is_cold else theme.pill_lang
-        parts.append(pill(bg, f"⏱ {cache_age_text}"))
+        bg = theme.s_hot if is_cold else theme.s_ok
+        parts.append(pill(bg, f"cache {cache_age_text}"))
 
     line = spacer.join(parts)
 
@@ -163,8 +163,8 @@ def render_hairline(
         parts.append(f"{MUTE}{lang_body}{RESET}")
 
     if cache_age_text:
-        col = _fg(theme.s_hot) if cache_age_text == "COLD" else MUTE
-        parts.append(f"{col}⏱ {cache_age_text}{RESET}")
+        col = _fg(theme.s_hot) if cache_age_text == "COLD" else _fg(theme.s_ok)
+        parts.append(f"{col}cache {cache_age_text}{RESET}")
 
     if bypass:
         parts.append(f"{_fg(theme.s_hot)}{BOLD}⚠ BYPASS{RESET}")
@@ -202,7 +202,11 @@ def render_classic(
         cost_text=cost_text,
     )
     if cache_age_text:
-        result += f" | ⏱ {cache_age_text}"
+        from .progress import GREEN, RED
+        col = RED if cache_age_text == "COLD" else GREEN
+        # Reset before our segment so it doesn't inherit the trailing color
+        # from format_status_line's last colorized chunk.
+        result += f"{RESET} | {colorize(f'cache {cache_age_text}', col, use_color)}"
     return result
 
 

--- a/tests/test_cache_age.py
+++ b/tests/test_cache_age.py
@@ -186,8 +186,8 @@ def test_cache_text_warm_minutes_format(tmp_path: Path, monkeypatch):
     _write_jsonl(transcript, [{"type": "assistant", "timestamp": ts.isoformat()}])
     _install_fake_cache(monkeypatch, tmp_path, {"transcript_path": str(transcript)})
     out = core.get_cache_age_text()
-    assert out.endswith(" ago")
     assert out.startswith("2m")
+    assert out.endswith("s")
 
 
 def test_cache_text_empty_when_cache_missing(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
Two visible issues with the cache-timer widget as shipped in #9–#11:

## 1. Label didn't read as cache
\"⏱ 15s ago\" looks like a generic stopwatch — users don't connect it to the prompt cache. Change to:
- warm: \`cache 15s\`  (green)
- cold: \`cache COLD\` (red)

\" ago\" was dropped — the word \`cache\` already implies elapsed time.

## 2. Classic-style color leaked
`format_status_line` ends with a colorized chunk and no trailing reset. Classic then raw-appended `f\" | ⏱ {cache_age_text}\"`, so when the row's overall color was red (e.g. 7d > critical), the cache segment rendered red regardless of state.

Fix: prepend `RESET` before the segment and colorize it independently with `GREEN`/`RED`.

Capsule and hairline already colored independently but used neutral palette colors (`pill_lang` bg / `MUTE` fg) for the warm state. Switch warm to `theme.s_ok` so warm/cold contrast is uniform across all three styles.

## Test plan
- [x] `PYTHONPATH=src python3 -m pytest -q` — 197 passed
- [x] Classic / capsule / hairline previews show `cache 30s` (warm, green) and `cache COLD` (red), no color bleed even when 7d% > critical.