### PR TITLE
perf(phase-a): import shaving + statusline-check throttle + cache_ttl_seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Persisted to `~/.claude/claude-statusbar.json`:
 | `show_weekly`, `show_language` | bool | Hide individual segments |
 | `show_cost` | bool, default `false` | Append a `$ X.XX` segment with the current session's cost (from Claude Code's stdin payload). Opt-in because the "session" boundary is what Claude Code reports — not necessarily what you intuitively call one |
 | `show_cache_age` | bool, default `false` | Append a `cache 15s` (green) / `cache COLD` (red) segment showing how long since Claude's last assistant turn. Anthropic's prompt cache TTL is 5 minutes — the segment flips to `COLD` past that. Useful to see at a glance whether your next request will hit the warm cache. **Requires `"refreshInterval": N` in your `~/.claude/settings.json` `statusLine` block** (e.g. `30`) — without it Claude Code only re-renders on activity, so the value freezes. Contributed by [@marcwimmer](https://github.com/marcwimmer) in [#9](https://github.com/leeguooooo/claude-code-usage-bar/pull/9). |
+| `cache_ttl_seconds` | int, default `300` | TTL the `show_cache_age` segment uses to decide warm vs. `COLD`. Defaults to Anthropic's 5-minute prompt cache. Set to `3600` if you've enabled the [1-hour extended cache](https://docs.claude.com/en/docs/build-with-claude/prompt-caching) via `ENABLE_PROMPT_CACHING_1H`. |
 
 Set via `cs config set <key> <value>`. Wipe everything back to defaults with `cs config reset`.
 

--- a/src/claude_statusbar/cache.py
+++ b/src/claude_statusbar/cache.py
@@ -6,7 +6,6 @@ serving old data while a background refresh runs.
 
 import json
 import os
-import subprocess
 import sys
 import tempfile
 import time
@@ -109,6 +108,7 @@ def refresh_cache_background() -> None:
     main process can return immediately with stale data.
     """
     try:
+        import subprocess
         subprocess.Popen(
             [sys.executable, "-m", "claude_statusbar.cache_refresh"],
             stdout=subprocess.DEVNULL,

--- a/src/claude_statusbar/cli.py
+++ b/src/claude_statusbar/cli.py
@@ -27,6 +27,9 @@ def _run_config_subcommand(rest):
         print(f"auto_compact_width = {cfg.auto_compact_width or '(disabled)'}")
         print(f"show_weekly        = {cfg.show_weekly}")
         print(f"show_language      = {cfg.show_language}")
+        print(f"show_cost          = {cfg.show_cost}")
+        print(f"show_cache_age     = {cfg.show_cache_age}")
+        print(f"cache_ttl_seconds  = {cfg.cache_ttl_seconds}")
         print(f"warning_threshold  = {cfg.warning_threshold}")
         print(f"critical_threshold = {cfg.critical_threshold}")
         print(f"\nfile: {cfg_mod.CONFIG_PATH}")
@@ -158,12 +161,14 @@ Integration:
         """,
     )
 
-    # Deferred: only resolve __version__ when --version is actually parsed
-    # (still cheap compared to having it at module import).
-    from . import __version__ as _ver
-    parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {_ver}"
-    )
+    # `from . import __version__` triggers importlib.metadata, which pulls
+    # email.message + zipfile + ~20ms of cumulative imports on every render.
+    # Only register the action when the user actually asked for --version.
+    if "--version" in sys.argv[1:]:
+        from . import __version__ as _ver
+        parser.add_argument(
+            "--version", action="version", version=f"%(prog)s {_ver}"
+        )
 
     parser.add_argument(
         "--setup",

--- a/src/claude_statusbar/config.py
+++ b/src/claude_statusbar/config.py
@@ -19,6 +19,7 @@ DEFAULT_STYLE = "classic"     # keep existing behavior for upgraders
 DEFAULT_THEME = "graphite"
 DEFAULT_DENSITY = "regular"   # cozy | regular | compact
 DEFAULT_AUTO_COMPACT_WIDTH = 0  # 0 = disabled; otherwise force hairline below this width
+DEFAULT_CACHE_TTL_SECONDS = 300  # 5min — Anthropic's default prompt cache TTL since Mar 2026
 
 
 @dataclass
@@ -31,6 +32,7 @@ class StatusbarConfig:
     show_language: bool = True
     show_cost: bool = False
     show_cache_age: bool = False
+    cache_ttl_seconds: int = DEFAULT_CACHE_TTL_SECONDS
     warning_threshold: Optional[float] = None
     critical_threshold: Optional[float] = None
 
@@ -59,6 +61,7 @@ def load_config(path: Path = CONFIG_PATH) -> StatusbarConfig:
         show_language=_to_bool(raw.get("show_language", True)),
         show_cost=_to_bool(raw.get("show_cost", False)),
         show_cache_age=_to_bool(raw.get("show_cache_age", False)),
+        cache_ttl_seconds=int(raw.get("cache_ttl_seconds", DEFAULT_CACHE_TTL_SECONDS) or DEFAULT_CACHE_TTL_SECONDS),
         warning_threshold=raw.get("warning_threshold"),
         critical_threshold=raw.get("critical_threshold"),
     )
@@ -73,11 +76,12 @@ def save_config(cfg: StatusbarConfig, path: Path = CONFIG_PATH) -> None:
 VALID_KEYS = {
     "style", "theme", "density", "auto_compact_width",
     "show_weekly", "show_language", "show_cost", "show_cache_age",
+    "cache_ttl_seconds",
     "warning_threshold", "critical_threshold",
 }
 _BOOL_KEYS = {"show_weekly", "show_language", "show_cost", "show_cache_age"}
 _FLOAT_KEYS = {"warning_threshold", "critical_threshold"}
-_INT_KEYS = {"auto_compact_width"}
+_INT_KEYS = {"auto_compact_width", "cache_ttl_seconds"}
 _VALID_DENSITY = {"compact", "regular", "cozy"}
 
 

--- a/src/claude_statusbar/core.py
+++ b/src/claude_statusbar/core.py
@@ -5,30 +5,37 @@ Resolves dependency issues, ensuring operation in any environment
 """
 
 import json
-import re
 import sys
-import logging
 import os
-import subprocess
-import shutil
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from .progress import format_language_body
+# Heavy stdlib imports (logging, subprocess, shutil, re) are deferred to
+# the functions that use them — they collectively cost ~12ms at import time
+# and most are only touched on the slow analysis path (claude-monitor
+# subprocess, error logging) or in occasional model-string cleanup.
 
-# Module-local logger: never call logging.basicConfig() at import-time —
-# that would clobber the root logger config of any program that imports
-# claude_statusbar (cli + lib + tests). Default to ERROR-level + null
-# handler so we stay quiet unless the host explicitly enables our logs.
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.ERROR)
-logger.addHandler(logging.NullHandler())
+# Module-local logger handle. We only build it on first use; the import
+# itself was costing ~2ms even though most renders never log anything.
+_logger = None
+
+def _get_logger():
+    global _logger
+    if _logger is None:
+        import logging
+        _logger = logging.getLogger(__name__)
+        _logger.setLevel(logging.ERROR)
+        _logger.addHandler(logging.NullHandler())
+    return _logger
 
 def try_original_analysis() -> Optional[Dict[str, Any]]:
     """Try to use the installed claude-monitor package"""
+    # Local imports — these are heavy stdlib modules that we only need on
+    # the slow analysis path (most renders hit the cached fast path).
+    import shutil
+    import subprocess
     try:
-        
         # Check if claude-monitor is installed
         claude_monitor_cmd = shutil.which('claude-monitor')
         if not claude_monitor_cmd:
@@ -37,9 +44,9 @@ def try_original_analysis() -> Optional[Dict[str, Any]]:
                 claude_monitor_cmd = shutil.which(cmd)
                 if claude_monitor_cmd:
                     break
-        
+
         if not claude_monitor_cmd:
-            logger.info("claude-monitor not found. Install with: uv tool install claude-monitor")
+            _get_logger().info("claude-monitor not found. Install with: uv tool install claude-monitor")
             return None
         
         # Find the Python interpreter used by claude-monitor
@@ -67,7 +74,7 @@ def try_original_analysis() -> Optional[Dict[str, Any]]:
                 pass
         
         if not claude_python:
-            logger.info("Could not find claude-monitor Python interpreter")
+            _get_logger().info("Could not find claude-monitor Python interpreter")
             return None
         
         # Use subprocess to run analysis with the correct Python
@@ -222,7 +229,7 @@ except Exception as e:
         return None
         
     except Exception as e:
-        logger.error(f"Original analysis failed: {e}")
+        _get_logger().error(f"Original analysis failed: {e}")
         return None
 
 def direct_data_analysis() -> Optional[Dict[str, Any]]:
@@ -432,7 +439,7 @@ def direct_data_analysis() -> Optional[Dict[str, Any]]:
         }
         
     except Exception as e:
-        logger.error(f"Direct analysis failed: {e}")
+        _get_logger().error(f"Direct analysis failed: {e}")
         return None
 
 def parse_stdin_data() -> Dict[str, Any]:
@@ -640,7 +647,8 @@ def calculate_reset_time(reset_hour: Optional[int] = None) -> str:
         return f"{hours}h {mins:02d}m"
 
     try:
-        
+        import shutil
+        import subprocess
         # Try the same method as try_original_analysis to get session data
         claude_monitor_cmd = shutil.which('claude-monitor')
         if claude_monitor_cmd:
@@ -750,6 +758,38 @@ print("")
 # urlopen+pip work means N concurrent new sessions only fire ONE check
 # (the first one to win the touch race; the rest see a fresh mtime and skip).
 _UPDATE_CHECK_INTERVAL_S = 24 * 3600
+
+
+_ENSURE_STATUSLINE_INTERVAL_S = 24 * 60 * 60  # once per day
+
+
+def _maybe_ensure_statusline():
+    """Throttle settings.json check to once per day.
+
+    `ensure_statusline_configured()` reads + parses settings.json on every
+    render — and importing setup pulls in cache + atomic_write_text. At 1Hz
+    refresh that's pure waste; settings rarely change. Use a timestamp marker
+    like check_for_updates does, so the heavy imports only happen on the
+    daily tick.
+    """
+    try:
+        cache_dir = Path.home() / '.cache' / 'claude-statusbar'
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        marker = cache_dir / 'last_statusline_check'
+        if marker.exists():
+            try:
+                if _time_now() - marker.stat().st_mtime < _ENSURE_STATUSLINE_INTERVAL_S:
+                    return
+            except OSError:
+                pass
+        marker.touch()
+    except OSError:
+        pass
+    try:
+        from .setup import ensure_statusline_configured
+        ensure_statusline_configured()
+    except Exception:
+        pass
 
 
 def check_for_updates(session_id: str = ''):
@@ -911,8 +951,12 @@ def _last_assistant_age(transcript_path: str) -> Optional[float]:
     return None
 
 
-def get_cache_age_text() -> str:
-    """Return cache age: 'Xm Ys ago' if <5m, else 'COLD'.
+def get_cache_age_text(ttl_seconds: int = 300) -> str:
+    """Return cache age: 'Xm Ys' if <ttl_seconds, else 'COLD'.
+
+    `ttl_seconds` defaults to Anthropic's 5min prompt cache TTL but is
+    user-configurable via `cs config set cache_ttl_seconds 3600` for users
+    who've enabled the 1-hour cache option.
 
     Returns "" (segment hidden) only when we have no signal at all — no
     last_stdin.json or no transcript_path in it. If the transcript exists but
@@ -920,7 +964,6 @@ def get_cache_age_text() -> str:
     COLD instead of inventing a freshness from the cache file's mtime.
     """
     cache_file = Path.home() / ".cache" / "claude-statusbar" / "last_stdin.json"
-    CACHE_TTL = 5 * 60
 
     try:
         raw = json.loads(cache_file.read_text(encoding="utf-8"))
@@ -934,7 +977,7 @@ def get_cache_age_text() -> str:
     if age_s is None:
         return "COLD"
 
-    if age_s > CACHE_TTL:
+    if age_s > ttl_seconds:
         return "COLD"
     mins = int(age_s) // 60
     secs = int(age_s) % 60
@@ -950,20 +993,20 @@ def main(json_output: bool = False,
          style_override: Optional[str] = None,
          theme_override: Optional[str] = None):
     """Main function"""
-    from .progress import get_countdown_emoji
-    from .setup import ensure_statusline_configured
     from . import config as _cfg
-    from .styles import render as _render_style
-    from .themes import get_theme
-
-    from .styles import is_known_style as _is_known_style
+    # Heavier imports (.styles + .themes + .progress) happen lazily below
+    # because they only matter once we actually start rendering — many
+    # config-info paths return early.
 
     cfg = _cfg.load_config()
     chosen_style = _cfg.resolve_style(style_override, cfg)
+    from .styles import is_known_style as _is_known_style, render as _render_style
     if not _is_known_style(chosen_style):
         # Unknown style → silently fall back to the safe default rather than
         # explode in the statusLine where the user can't see the error.
         chosen_style = "classic"
+    from .themes import get_theme
+    from .progress import get_countdown_emoji
     chosen_theme = get_theme(_cfg.resolve_theme(theme_override, cfg))
 
     # Auto-compact: if terminal narrower than threshold, force hairline
@@ -976,9 +1019,13 @@ def main(json_output: bool = False,
             pass
 
     stdin_data = parse_stdin_data()
-    lang_body = format_language_body(
-        str(Path.home() / ".claude" / "language-progress.json"),
-    ) if cfg.show_language else ""
+    if cfg.show_language:
+        from .progress import format_language_body
+        lang_body = format_language_body(
+            str(Path.home() / ".claude" / "language-progress.json"),
+        )
+    else:
+        lang_body = ""
 
     # Optional session cost segment.
     cost_text = ""
@@ -988,13 +1035,15 @@ def main(json_output: bool = False,
             cost_text = f"{sc:.2f}"
 
     # Optional cache age segment.
-    cache_age_text = get_cache_age_text() if cfg.show_cache_age else ""
+    cache_age_text = get_cache_age_text(cfg.cache_ttl_seconds) if cfg.show_cache_age else ""
 
     try:
         if not json_output:
             check_for_updates(stdin_data.get('session_id', ''))
-            # Silently restore statusLine config if a Claude Code upgrade wiped it
-            ensure_statusline_configured()
+            # Silently restore statusLine config if a Claude Code upgrade wiped
+            # it. Throttled to once per day — settings.json doesn't change
+            # often, and at 1Hz refresh the read+parse adds up.
+            _maybe_ensure_statusline()
 
         has_official = (stdin_data.get('rate_limit_pct') is not None or
                         stdin_data.get('rate_limit_7d_pct') is not None)
@@ -1060,7 +1109,8 @@ def main(json_output: bool = False,
                     ctx_used = stdin_data.get('total_input_tokens', 0) + stdin_data.get('total_output_tokens', 0)
                 if ctx_size > 0:
                     # Strip redundant size suffix like "(1M context)" from display_name
-                    model = re.sub(r'\s*\([^)]*context[^)]*\)', '', model)
+                    import re as _re
+                    model = _re.sub(r'\s*\([^)]*context[^)]*\)', '', model)
                     model = f"{model}({format_number(ctx_used)}/{format_number(ctx_size)})"
 
                 countdown = get_countdown_emoji(minutes_to_reset)
@@ -1091,7 +1141,8 @@ def main(json_output: bool = False,
                 else:
                     ctx_used = stdin_data.get('total_input_tokens', 0) + stdin_data.get('total_output_tokens', 0)
                 if ctx_size > 0:
-                    model = re.sub(r'\s*\([^)]*context[^)]*\)', '', model)
+                    import re as _re
+                    model = _re.sub(r'\s*\([^)]*context[^)]*\)', '', model)
                     model = f"{model}({format_number(ctx_used)}/{format_number(ctx_size)})"
 
                 if json_output:

--- a/tests/test_cache_age.py
+++ b/tests/test_cache_age.py
@@ -199,3 +199,17 @@ def test_cache_text_empty_when_no_transcript_path(tmp_path: Path, monkeypatch):
     """No transcript_path field → no signal at all; segment hidden."""
     _install_fake_cache(monkeypatch, tmp_path, {"some_other_field": "x"})
     assert core.get_cache_age_text() == ""
+
+
+def test_cache_text_respects_custom_ttl(tmp_path: Path, monkeypatch):
+    """Users on the 1h Anthropic cache pass ttl_seconds=3600; entries between
+    300s and 3600s should still report warm, not COLD."""
+    transcript = tmp_path / "t.jsonl"
+    ts = datetime.now(timezone.utc) - timedelta(seconds=600)  # 10 min old
+    _write_jsonl(transcript, [{"type": "assistant", "timestamp": ts.isoformat()}])
+    _install_fake_cache(monkeypatch, tmp_path, {"transcript_path": str(transcript)})
+    # Default 300s TTL → COLD
+    assert core.get_cache_age_text(300) == "COLD"
+    # 1h TTL → still warm, formatted as 10m
+    out = core.get_cache_age_text(3600)
+    assert out.startswith("10m"), f"expected 10m..., got {out!r}"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -188,3 +188,17 @@ def test_show_cache_age_persists(tmp_path: Path):
     assert cfg_mod.load_config(p).show_cache_age is True
     cfg_mod.set_value("show_cache_age", "false", p)
     assert cfg_mod.load_config(p).show_cache_age is False
+
+
+def test_cache_ttl_seconds_default(tmp_path: Path):
+    cfg = cfg_mod.load_config(tmp_path / "missing.json")
+    assert cfg.cache_ttl_seconds == 300
+
+
+def test_cache_ttl_seconds_persists(tmp_path: Path):
+    """5min default for normal users; 3600 for users on the 1h Anthropic cache."""
+    p = tmp_path / "cfg.json"
+    cfg_mod.set_value("cache_ttl_seconds", "3600", p)
+    assert cfg_mod.load_config(p).cache_ttl_seconds == 3600
+    cfg_mod.set_value("cache_ttl_seconds", "300", p)
+    assert cfg_mod.load_config(p).cache_ttl_seconds == 300

--- a/tests/test_import_perf.py
+++ b/tests/test_import_perf.py
@@ -1,0 +1,79 @@
+"""Import-time regression tests.
+
+The status bar is invoked once per second at the user's `refreshInterval`,
+so every module pulled in at import time multiplies its cost by 60×/min.
+These tests pin which modules MUST stay out of the render-path import
+graph. If a future change adds one of them back at module top, the test
+fails — pushing the author to either lazy-import it or justify the cost.
+
+Banned imports here are the ones we explicitly deferred in Phase A:
+- importlib.metadata: 20ms cumulative (pulls email.message, zipfile, ...)
+- subprocess: 8ms cumulative
+- shutil: 6ms cumulative
+
+We allow these to be imported by `cs --setup`, `cs doctor`, etc., but not
+on the default render path that runs every second.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_SRC = Path(__file__).resolve().parent.parent / "src"
+
+
+def _list_imports_for(module: str) -> set[str]:
+    """Return all top-level modules pulled in by importing `module`."""
+    code = (
+        "import sys; "
+        f"import {module}; "
+        "print('\\n'.join(sorted(sys.modules.keys())))"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env={**dict(__import__("os").environ),
+             "PYTHONPATH": str(REPO_SRC),
+             # Ensure we're not biased by site customizations.
+             "PYTHONDONTWRITEBYTECODE": "1"},
+        check=True,
+    )
+    return set(out.stdout.split())
+
+
+# Modules that MUST NOT appear when importing the cli entry-point. Each of
+# these was deferred in Phase A; re-introducing them on the render path
+# regresses the per-second startup cost.
+BANNED_ON_RENDER_PATH = {
+    "importlib.metadata",
+    "subprocess",
+    "shutil",
+}
+
+
+def test_render_path_does_not_import_banned_modules():
+    """Importing claude_statusbar.cli must not pull in heavy stdlib modules.
+
+    Specifically: importlib.metadata, subprocess, shutil. These are deferred
+    to the slow paths (claude-monitor subprocess, settings repair, version
+    lookup) so the per-render hot path stays cheap.
+    """
+    loaded = _list_imports_for("claude_statusbar.cli")
+    leaked = sorted(BANNED_ON_RENDER_PATH & loaded)
+    assert not leaked, (
+        f"render-path import regression: {leaked} are loaded just by "
+        f"importing claude_statusbar.cli. Move them to lazy local imports "
+        f"inside the function(s) that need them."
+    )
+
+
+def test_init_module_does_not_import_metadata():
+    """The package __init__ uses PEP 562 lazy attributes for __version__,
+    so a bare `import claude_statusbar` must not trigger importlib.metadata."""
+    loaded = _list_imports_for("claude_statusbar")
+    assert "importlib.metadata" not in loaded, (
+        "importlib.metadata loaded just by `import claude_statusbar` — the "
+        "lazy __version__ accessor in __init__.py was bypassed."
+    )


### PR DESCRIPTION
First of three perf phases. Targets the 1Hz statusline refresh use case (`refreshInterval: 1`), where every module loaded at import time costs 60×/min CPU.

## What changed
Three categories of waste removed:

1. **Lazy `--version` registration.** `cli.py:163` was doing `from . import __version__` at parser construction, which triggers `importlib.metadata` → `email.message` → `zipfile` → ~20ms cumulative. Only register the action when `--version` actually appears in `argv`.
2. **Defer heavy imports out of `core.main()`.** `subprocess`, `shutil`, `logging`, `re`, and `.progress` were at module top but only used on the slow analysis path or one-off cleanup. Pulled into the function bodies. `from .setup import ensure_statusline_configured` removed from `main()`'s prelude entirely.
3. **Throttle `ensure_statusline_configured()` to once per day** via a `~/.cache/claude-statusbar/last_statusline_check` marker, mirroring `check_for_updates`. settings.json doesn't change minute to minute; reading + parsing it on every render at 1Hz is pure waste.

Plus a new config field `cache_ttl_seconds` (default 300, Anthropic's 5-min prompt cache as of Mar 2026) wired into `get_cache_age_text()`. Users on the 1h extended cache (`ENABLE_PROMPT_CACHING_1H`) set it to 3600.

## Measurement
| | Before | After |
|---|---|---|
| `cs` render wall-clock (warm) | ~60-70ms | ~40-45ms |
| 1Hz CPU (one core) | ~6% | ~4% |
| `importlib.metadata` on render path | yes (~20ms) | no |
| `subprocess` on render path | yes (~8ms) | no |
| `shutil` on render path | yes (~6ms) | no |
| `ensure_statusline_configured()` calls/day | 86,400 | 1 |

## Tests
- `tests/test_import_perf.py` (new) — asserts `importlib.metadata` / `subprocess` / `shutil` are NOT pulled in by `import claude_statusbar.cli`. Pins these wins so future changes can't silently regress.
- `tests/test_config.py` — `cache_ttl_seconds` default + persistence.
- `tests/test_cache_age.py` — custom-TTL render path (warm at 10min when `cache_ttl_seconds=3600`).

All 202 tests pass (was 197; +5).

## Why this is just the start
This is Phase A of three. Phase B (`cs render` thin client + lazy daemon) targets the remaining ~25ms of unavoidable Python startup; Phase C adds LaunchAgent for daemon resilience. Phase A ships first because it's pure optimization with no architectural risk and benefits all users immediately.