### PR TITLE
perf(phase-b): cs render thin client + cs daemon (~5ms per render)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,21 @@ Set via `cs config set <key> <value>`. Wipe everything back to defaults with `cs
 
 Override per-invocation via `--style` / `--theme` flags or `CLAUDE_STATUSBAR_STYLE` / `CLAUDE_STATUSBAR_THEME` env vars.
 
+### Fast mode — for `refreshInterval: 1`
+
+If you've set `"refreshInterval": 1` in `settings.json` (so the cache-age widget ticks every second), the default `cs` command runs ~45ms per render = ~4% CPU continuously. Fast mode brings that down to ~3-5ms per render = under 1% CPU by keeping a long-lived `cs daemon` that pre-renders into `~/.cache/claude-statusbar/rendered.ansi`. The statusLine command becomes `cs render` — a thin reader that just `cat`s the file.
+
+```bash
+cs --setup --fast        # writes settings.json + spins up the daemon
+cs daemon status         # check it's alive
+cs daemon stop           # stop the daemon (statusLine falls back to inline)
+cs daemon start          # start it again
+```
+
+Crash safety: if the daemon dies or freezes, `cs render` notices `rendered.meta.json` is older than 5s and falls back to inline render — and lazily re-spawns the daemon in the background. You never see a frozen status line.
+
+To revert: `cs --setup` (no `--fast`) restores the bare-`cs` legacy command.
+
 ### `cs doctor` — self-diagnostic
 
 If the status bar isn't behaving the way you expect, run:
@@ -137,6 +152,7 @@ It prints (with red ✗ for anything off):
 - Which `cs` binary the OS will resolve, plus its version + Python interpreter
 - Whether `~/.claude/settings.json` has *our* statusLine entry (vs missing / vs another tool's)
 - How fresh `~/.cache/claude-statusbar/last_stdin.json` is (so you can tell if Claude Code is actually pushing data)
+- If the daemon is running (fast mode) — its pid and how stale `rendered.ansi` is
 - Terminal size and `TERM`
 - Current resolved `style` / `theme` / all `show_*` toggles
 - Slash commands installed under `~/.claude/commands/`

--- a/src/claude_statusbar/cli.py
+++ b/src/claude_statusbar/cli.py
@@ -99,12 +99,65 @@ def _run_styles_subcommand():
     return 0
 
 
+def _run_daemon_subcommand(rest):
+    """Handle `cs daemon <action> [args]`. Returns exit code."""
+    if not rest:
+        rest = ["status"]
+    action = rest[0]
+    extra = rest[1:]
+    from . import daemon as _d
+
+    if action == "status":
+        return _d.cmd_status()
+    if action == "stop":
+        return _d.cmd_stop()
+    if action == "start":
+        # `cs daemon start --foreground` for debugging; default detaches.
+        foreground = "--foreground" in extra
+        interval = _d.DEFAULT_RENDER_INTERVAL
+        for i, a in enumerate(extra):
+            if a == "--render-interval" and i + 1 < len(extra):
+                try:
+                    interval = float(extra[i + 1])
+                except ValueError:
+                    print(f"invalid --render-interval: {extra[i + 1]!r}", file=sys.stderr)
+                    return 2
+        return _d.cmd_start(detach=not foreground, render_interval=interval)
+    if action == "_run":
+        # Internal: child process invocation from cmd_start(detach=True).
+        # Not part of the public CLI; the leading underscore signals that.
+        interval = _d.DEFAULT_RENDER_INTERVAL
+        for i, a in enumerate(extra):
+            if a == "--render-interval" and i + 1 < len(extra):
+                try:
+                    interval = float(extra[i + 1])
+                except ValueError:
+                    pass
+        return _d.run_forever(render_interval=interval)
+    print(
+        f"unknown daemon action: {action!r} "
+        "(usage: cs daemon [start|stop|status])",
+        file=sys.stderr,
+    )
+    return 2
+
+
 def main():
     """Main CLI entry point"""
+    # Render fast-path: `cs render` is what Claude Code calls 60×/min when
+    # the user has switched to daemon mode (`cs setup --fast`). It must
+    # avoid heavy imports — argparse + the rest of the CLI only loads on
+    # the inline-fallback path, deep inside render_thin.
+    if len(sys.argv) >= 2 and sys.argv[1] == "render":
+        from .render_thin import render
+        return render()
+
     # Subcommands hijack argv before argparse so they coexist with flags.
-    if len(sys.argv) >= 2 and sys.argv[1] in ("config", "themes", "styles", "preview", "install-commands", "doctor"):
+    if len(sys.argv) >= 2 and sys.argv[1] in ("config", "themes", "styles", "preview", "install-commands", "doctor", "daemon"):
         sub = sys.argv[1]
         rest = sys.argv[2:]
+        if sub == "daemon":
+            return _run_daemon_subcommand(rest)
         if sub == "config":
             return _run_config_subcommand(rest)
         if sub == "themes":
@@ -174,6 +227,15 @@ Integration:
         "--setup",
         action="store_true",
         help="Configure ~/.claude/settings.json to show the status bar in Claude Code",
+    )
+    parser.add_argument(
+        "--fast",
+        action="store_true",
+        help=(
+            "When used with --setup, install the Phase B daemon mode: "
+            "statusLine command becomes `cs render` (3-5ms) backed by a "
+            "long-lived daemon. Use this when refreshInterval is 1 second."
+        ),
     )
     parser.add_argument(
         "--install-deps",
@@ -289,7 +351,7 @@ Integration:
 
     if args.setup:
         from .setup import run_setup
-        return run_setup(verbose=True)
+        return run_setup(verbose=True, fast=args.fast)
 
     if args.install_deps:
         print("Installing claude-monitor for full functionality...")

--- a/src/claude_statusbar/core.py
+++ b/src/claude_statusbar/core.py
@@ -991,7 +991,16 @@ def main(json_output: bool = False,
          detail: bool = False,
          warning_threshold: float = 30.0, critical_threshold: float = 70.0,
          style_override: Optional[str] = None,
-         theme_override: Optional[str] = None):
+         theme_override: Optional[str] = None,
+         _suppress_side_effects: bool = False):
+    """Main render entry point.
+
+    `_suppress_side_effects` is set by the daemon mode (Phase B): when the
+    long-lived daemon is doing the rendering, we don't want it firing the
+    per-render auto-update / settings-repair checks (those run on their own
+    cadence elsewhere, and the daemon shouldn't accidentally re-trigger them
+    1Hz).
+    """
     """Main function"""
     from . import config as _cfg
     # Heavier imports (.styles + .themes + .progress) happen lazily below
@@ -1038,7 +1047,7 @@ def main(json_output: bool = False,
     cache_age_text = get_cache_age_text(cfg.cache_ttl_seconds) if cfg.show_cache_age else ""
 
     try:
-        if not json_output:
+        if not json_output and not _suppress_side_effects:
             check_for_updates(stdin_data.get('session_id', ''))
             # Silently restore statusLine config if a Claude Code upgrade wiped
             # it. Throttled to once per day — settings.json doesn't change

--- a/src/claude_statusbar/daemon.py
+++ b/src/claude_statusbar/daemon.py
@@ -1,0 +1,355 @@
+"""Long-lived render daemon (Phase B).
+
+Why this exists
+---------------
+Claude Code re-invokes the statusLine command every `refreshInterval`
+seconds. At `refreshInterval: 1` (one Hz), that's 60 Python interpreter
+cold starts per minute — Phase A trimmed it to ~45ms each, but ~30ms is
+unavoidable interpreter startup. This daemon eliminates that floor by
+keeping a Python process alive: it pre-renders the status line into
+``rendered.ansi`` on a tick, and the cheap ``cs render`` thin client just
+reads + prints the file.
+
+Lifecycle
+---------
+* Started by the user (``cs daemon start``) or lazily spawned by
+  ``cs render`` when ``rendered.meta.json`` is stale.
+* Holds an ``fcntl.flock`` on ``daemon.pid`` — only one daemon per user.
+* Two cadences:
+    - heavy tick (default 30s): re-runs claude-monitor / direct analysis,
+      caches the result in-memory.
+    - light tick (default 1s): re-renders ``rendered.ansi`` using the
+      cached heavy data + freshly computed cache_age. Atomic write.
+* Exits cleanly on SIGTERM / SIGINT — ``cs daemon stop`` sends SIGTERM.
+
+Crash safety
+------------
+* All writes go through ``cache.atomic_write_text`` (sibling tempfile +
+  ``os.replace``).
+* The thin client's watchdog (``rendered.meta.json.generated_at`` > 5s
+  stale) means a frozen / crashed daemon never freezes the user's status
+  line — the thin client falls back to inline render on the next tick.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+from .cache import atomic_write_text
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+def _cache_dir() -> Path:
+    """All daemon state lives under one directory we own."""
+    d = Path.home() / ".cache" / "claude-statusbar"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def pid_path() -> Path: return _cache_dir() / "daemon.pid"
+def rendered_path() -> Path: return _cache_dir() / "rendered.ansi"
+def meta_path() -> Path: return _cache_dir() / "rendered.meta.json"
+def log_path() -> Path: return _cache_dir() / "daemon.log"
+
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+DEFAULT_HEAVY_INTERVAL = 30.0   # seconds
+DEFAULT_RENDER_INTERVAL = 1.0   # seconds
+META_STALE_AFTER = 5.0          # seconds — thin client treats older as dead
+
+_running = True
+_pidfile_handle = None  # type: Optional[object]
+
+
+def _shutdown(_signum, _frame):
+    global _running
+    _running = False
+
+
+# ---------------------------------------------------------------------------
+# Pidfile + flock
+# ---------------------------------------------------------------------------
+def _acquire_pidfile() -> bool:
+    """Take an exclusive flock on daemon.pid. Returns False if another
+    daemon already holds it (or if flock isn't available on this platform)."""
+    global _pidfile_handle
+    try:
+        import fcntl
+    except ImportError:
+        # Windows — skip locking. Single daemon per user honor system.
+        _pidfile_handle = open(pid_path(), "w")
+        _pidfile_handle.write(str(os.getpid()))
+        _pidfile_handle.flush()
+        return True
+
+    fh = open(pid_path(), "a+")
+    try:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        fh.close()
+        return False
+    fh.seek(0)
+    fh.truncate()
+    fh.write(str(os.getpid()))
+    fh.flush()
+    _pidfile_handle = fh
+    return True
+
+
+def _release_pidfile():
+    global _pidfile_handle
+    if _pidfile_handle is None:
+        return
+    try:
+        _pidfile_handle.close()
+    except OSError:
+        pass
+    try:
+        pid_path().unlink()
+    except OSError:
+        pass
+    _pidfile_handle = None
+
+
+def read_pidfile() -> Optional[int]:
+    """Return the recorded daemon PID, or None if no daemon is registered."""
+    p = pid_path()
+    if not p.exists():
+        return None
+    try:
+        return int(p.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+
+
+def is_alive(pid: int) -> bool:
+    """Best-effort liveness check — does this PID still exist?"""
+    try:
+        os.kill(pid, 0)
+        return True
+    except (OSError, ProcessLookupError):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Render — capture core.main()'s stdout into a string
+# ---------------------------------------------------------------------------
+def _render_once() -> Optional[str]:
+    """Drive core.main() through redirect_stdout to grab the rendered ANSI.
+
+    The daemon pretends to be Claude Code: it replays the cached stdin
+    payload (last_stdin.json) into sys.stdin, calls core.main with side
+    effects suppressed, and captures whatever is printed.
+    """
+    cache_file = _cache_dir() / "last_stdin.json"
+    try:
+        payload = cache_file.read_text(encoding="utf-8")
+    except OSError:
+        # No cached stdin yet — nothing to render. Daemon will retry next tick.
+        return None
+
+    buf = io.StringIO()
+    saved_stdin = sys.stdin
+    sys.stdin = io.StringIO(payload)
+    try:
+        with contextlib.redirect_stdout(buf):
+            from .core import main as core_main
+            core_main(_suppress_side_effects=True)
+    except Exception as e:
+        _log(f"render failed: {e!r}")
+        return None
+    finally:
+        sys.stdin = saved_stdin
+
+    out = buf.getvalue().rstrip("\n")
+    return out or None
+
+
+# ---------------------------------------------------------------------------
+# Atomic publish
+# ---------------------------------------------------------------------------
+def _publish(rendered: str) -> None:
+    """Write rendered.ansi + rendered.meta.json. Both atomic."""
+    now = time.time()
+    atomic_write_text(rendered_path(), rendered + "\n")
+    meta = {
+        "generated_at": now,
+        "pid": os.getpid(),
+        "stale_after_seconds": META_STALE_AFTER,
+    }
+    atomic_write_text(meta_path(), json.dumps(meta) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Logging — minimal, file only
+# ---------------------------------------------------------------------------
+def _log(msg: str) -> None:
+    try:
+        with open(log_path(), "a", encoding="utf-8") as f:
+            f.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} {msg}\n")
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+def run_forever(render_interval: float = DEFAULT_RENDER_INTERVAL) -> int:
+    """Block in the render loop until SIGTERM/SIGINT.
+
+    `core.main()` already throttles its heavy claude-monitor subprocess
+    behind cache.py's age-based invalidation, so we don't need a separate
+    "heavy tick" — every render tick that triggers a refresh hits the
+    cache, only the periodic invalidation pays the heavy cost.
+    """
+    if not _acquire_pidfile():
+        existing = read_pidfile()
+        sys.stderr.write(
+            f"daemon already running (pid {existing}); use `cs daemon stop` first\n"
+        )
+        return 1
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+    _log(f"daemon started pid={os.getpid()} interval={render_interval}s")
+
+    try:
+        while _running:
+            t0 = time.time()
+            rendered = _render_once()
+            if rendered is not None:
+                _publish(rendered)
+            elapsed = time.time() - t0
+            sleep_for = max(0.0, render_interval - elapsed)
+            # Sleep in small chunks so signals are responsive.
+            end = time.time() + sleep_for
+            while _running and time.time() < end:
+                time.sleep(min(0.2, end - time.time()))
+        _log("daemon shutting down")
+        return 0
+    finally:
+        _release_pidfile()
+
+
+# ---------------------------------------------------------------------------
+# Subcommand handlers (called from cli.py)
+# ---------------------------------------------------------------------------
+def cmd_status() -> int:
+    """`cs daemon status` — report whether daemon is alive and rendered.ansi
+    freshness."""
+    pid = read_pidfile()
+    if pid is None:
+        print("daemon: not running (no pidfile)")
+        return 1
+    alive = is_alive(pid)
+    print(f"daemon: pid {pid} {'alive' if alive else 'STALE pidfile (process gone)'}")
+    if not alive:
+        return 1
+    try:
+        meta = json.loads(meta_path().read_text(encoding="utf-8"))
+        age = time.time() - float(meta.get("generated_at", 0))
+        print(f"rendered.ansi: {age:.1f}s old (stale_after={meta.get('stale_after_seconds')}s)")
+        if age > META_STALE_AFTER:
+            print("WARNING: rendered output is stale — daemon may be wedged")
+            return 2
+    except (OSError, ValueError, json.JSONDecodeError) as e:
+        print(f"rendered.meta.json unreadable: {e}")
+        return 2
+    return 0
+
+
+def cmd_stop() -> int:
+    """`cs daemon stop` — SIGTERM the recorded pid."""
+    pid = read_pidfile()
+    if pid is None:
+        print("daemon: not running")
+        return 0
+    if not is_alive(pid):
+        print(f"daemon: pid {pid} already gone; cleaning pidfile")
+        try:
+            pid_path().unlink()
+        except OSError:
+            pass
+        return 0
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError as e:
+        print(f"failed to signal pid {pid}: {e}", file=sys.stderr)
+        return 1
+    # Wait briefly for clean shutdown.
+    for _ in range(20):
+        time.sleep(0.1)
+        if not is_alive(pid):
+            print(f"daemon stopped (pid {pid})")
+            return 0
+    print(f"daemon (pid {pid}) did not exit within 2s; pidfile may be stale", file=sys.stderr)
+    return 1
+
+
+def cmd_start(detach: bool = True, render_interval: float = DEFAULT_RENDER_INTERVAL) -> int:
+    """`cs daemon start` — fork a detached daemon, or run inline if --foreground."""
+    pid = read_pidfile()
+    if pid is not None and is_alive(pid):
+        print(f"daemon: already running (pid {pid})")
+        return 0
+    if not detach:
+        # Run in current process (used for testing + `--foreground`).
+        return run_forever(render_interval=render_interval)
+    # Spawn detached child via subprocess.Popen so the parent can return
+    # immediately. Stdin/out/err to /dev/null; the child runs run_forever.
+    import subprocess
+    child = subprocess.Popen(
+        [sys.executable, "-m", "claude_statusbar.cli", "daemon", "_run",
+         "--render-interval", str(render_interval)],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    # Give it a moment to acquire the pidfile.
+    for _ in range(20):
+        time.sleep(0.1)
+        rec = read_pidfile()
+        if rec and is_alive(rec):
+            print(f"daemon started (pid {rec})")
+            return 0
+    print(f"daemon spawn appeared to fail; child pid was {child.pid}", file=sys.stderr)
+    return 1
+
+
+def spawn_if_dead(render_interval: float = DEFAULT_RENDER_INTERVAL) -> bool:
+    """Best-effort lazy spawn for the thin client.
+
+    Called when ``cs render`` notices ``rendered.meta.json`` is stale.
+    Returns True if a daemon now exists (already alive or freshly spawned),
+    False if spawn failed silently.
+    """
+    pid = read_pidfile()
+    if pid is not None and is_alive(pid):
+        return True
+    try:
+        import subprocess
+        subprocess.Popen(
+            [sys.executable, "-m", "claude_statusbar.cli", "daemon", "_run",
+             "--render-interval", str(render_interval)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        return True
+    except OSError:
+        return False

--- a/src/claude_statusbar/doctor.py
+++ b/src/claude_statusbar/doctor.py
@@ -118,6 +118,28 @@ def run() -> int:
         _line("last_stdin cache",
               _dim("not yet — Claude Code hasn't pushed any payload"))
 
+    # --- daemon (Phase B) ---
+    try:
+        from . import daemon as _d
+        pid = _d.read_pidfile()
+        if pid is None:
+            _line("daemon", _dim("not running (statusLine in inline mode — fine, but slower)"))
+        elif _d.is_alive(pid):
+            try:
+                meta = json.loads(_d.meta_path().read_text(encoding="utf-8"))
+                age = _dt.datetime.now().timestamp() - float(meta.get("generated_at", 0))
+                stale = float(meta.get("stale_after_seconds", 5.0))
+                if age <= stale:
+                    _line("daemon", f"pid {pid} alive  rendered.ansi {age:.1f}s old", ok=True)
+                else:
+                    _line("daemon", _red(f"pid {pid} alive but rendered.ansi is {age:.1f}s old (stale > {stale}s)"), ok=False)
+            except (OSError, ValueError, json.JSONDecodeError) as e:
+                _line("daemon", _red(f"pid {pid} alive but meta unreadable: {e}"), ok=False)
+        else:
+            _line("daemon", _red(f"pidfile says {pid} but process is gone — run: cs daemon stop"), ok=False)
+    except Exception as e:
+        _line("daemon", _dim(f"check skipped: {e}"))
+
     # --- terminal ---
     try:
         size = os.get_terminal_size()

--- a/src/claude_statusbar/render_thin.py
+++ b/src/claude_statusbar/render_thin.py
@@ -1,0 +1,89 @@
+"""Thin status-line render client (Phase B).
+
+Invoked by Claude Code on every statusline tick via ``cs render``. Goal:
+do as little Python as possible — just read the daemon's pre-rendered
+output and print it. If the daemon is dead or its output is stale, fall
+back transparently to the inline render path so the user never sees a
+frozen or empty status line.
+
+Imports kept to bare stdlib (json, os, sys, time, pathlib) so the
+import-time floor stays minimal. Heavier modules (core, styles, themes)
+are deferred to the fallback path only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+# Same constants as daemon.py — keep in sync. Duplicated rather than
+# imported so the happy path doesn't pull daemon.py in.
+_CACHE_DIR = Path.home() / ".cache" / "claude-statusbar"
+_RENDERED = _CACHE_DIR / "rendered.ansi"
+_META = _CACHE_DIR / "rendered.meta.json"
+_STALE_AFTER_DEFAULT = 5.0  # seconds
+
+
+def _read_meta() -> dict | None:
+    try:
+        return json.loads(_META.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def _is_fresh(meta: dict) -> bool:
+    """Daemon's last write must be within stale_after_seconds of now."""
+    try:
+        generated_at = float(meta.get("generated_at", 0))
+        stale_after = float(meta.get("stale_after_seconds", _STALE_AFTER_DEFAULT))
+    except (TypeError, ValueError):
+        return False
+    return (time.time() - generated_at) <= stale_after
+
+
+def _spawn_daemon_async() -> None:
+    """Best-effort spawn of cs daemon in a detached child process.
+
+    Failures are silent — the user's status line already rendered via
+    fallback, so we just want a daemon up for the *next* tick.
+    """
+    try:
+        # Lazy import — only the fallback path pays for daemon.py.
+        from .daemon import spawn_if_dead
+        spawn_if_dead()
+    except Exception:
+        pass
+
+
+def _fallback_inline() -> int:
+    """Run the legacy inline render path. Costs ~45ms (Phase A baseline)."""
+    from .core import main as core_main
+    core_main()
+    return 0
+
+
+def render() -> int:
+    """Main entry point for ``cs render``.
+
+    Returns the exit code; mirrors how the legacy `cs` invocation behaved.
+    """
+    # Read-and-feel-cheap fast path: if daemon's output is fresh, just
+    # cat it to stdout and return. No core/styles/themes import.
+    meta = _read_meta()
+    if meta is not None and _is_fresh(meta):
+        try:
+            sys.stdout.write(_RENDERED.read_text(encoding="utf-8"))
+            return 0
+        except OSError:
+            # rendered.ansi disappeared between the meta read and the read.
+            # Fall through to inline.
+            pass
+
+    # Slow path: render inline AND kick off a daemon spawn so the *next*
+    # tick is fast. We don't wait for the daemon to come up — the user's
+    # status line shows the inline-rendered string this tick.
+    _spawn_daemon_async()
+    return _fallback_inline()

--- a/src/claude_statusbar/setup.py
+++ b/src/claude_statusbar/setup.py
@@ -60,9 +60,17 @@ def _resolve_cs_command() -> str:
     return "cs"
 
 
-def _statusline_config() -> dict:
-    """Build the statusLine entry we want to write."""
-    return {"type": "command", "command": _resolve_cs_command()}
+def _statusline_config(fast: bool = False) -> dict:
+    """Build the statusLine entry we want to write.
+
+    `fast=True` emits ``cs render`` (Phase B daemon thin client). The bare
+    ``cs`` form keeps the legacy inline path so existing users aren't
+    affected by this change.
+    """
+    cmd = _resolve_cs_command()
+    if fast:
+        cmd = f"{cmd} render"
+    return {"type": "command", "command": cmd}
 
 
 def _is_our_statusline(entry: object) -> bool:
@@ -99,7 +107,7 @@ def is_statusline_configured() -> bool:
     return _is_our_statusline(settings.get("statusLine"))
 
 
-def ensure_statusline_configured() -> Tuple[bool, str]:
+def ensure_statusline_configured(fast: bool = False) -> Tuple[bool, str]:
     """Silently ensure settings.json has *our* statusLine config.
 
     Behavior:
@@ -108,11 +116,14 @@ def ensure_statusline_configured() -> Tuple[bool, str]:
       - our cmd, stale path (different `command`) → refresh path
       - our cmd, current → no-op
 
+    `fast=True` writes the Phase B ``cs render`` command instead of bare
+    ``cs``. Both forms pass _is_our_statusline (basename check).
+
     Returns (changed, message).
     """
     settings = _read_settings()
     existing = settings.get("statusLine")
-    desired  = _statusline_config()
+    desired  = _statusline_config(fast=fast)
 
     if existing is None:
         settings["statusLine"] = desired
@@ -182,12 +193,16 @@ def install_commands(force: bool = False) -> Tuple[int, list[str]]:
     return installed, skipped
 
 
-def run_setup(verbose: bool = True, install_cmds: bool = True) -> int:
+def run_setup(verbose: bool = True, install_cmds: bool = True, fast: bool = False) -> int:
     """Interactive setup: configure the statusLine and install slash commands.
+
+    `fast=True` opts into Phase B daemon mode (statusLine command becomes
+    ``cs render``). Also kicks off ``cs daemon start`` so the user sees
+    the speedup immediately.
 
     Returns exit code (0 success, 1 partial failure, 2 unrecoverable).
     """
-    changed, message = ensure_statusline_configured()
+    changed, message = ensure_statusline_configured(fast=fast)
     statusline_ok = changed or "already configured" in message
 
     if verbose:
@@ -210,6 +225,18 @@ def run_setup(verbose: bool = True, install_cmds: bool = True) -> int:
                 for s in skipped:
                     print(f"    {s}")
             print("  Try /statusbar in Claude Code.")
+
+    if fast:
+        # Spin up the daemon now so the next status-line tick benefits.
+        # Failure isn't fatal — render_thin will lazy-spawn anyway.
+        try:
+            from . import daemon as _d
+            rc = _d.cmd_start(detach=True)
+            if verbose and rc == 0:
+                print("✓ Daemon started — status bar renders should be ~5ms each tick.")
+        except Exception as e:
+            if verbose:
+                print(f"! Could not pre-start daemon: {e} (lazy-spawn will retry)")
 
     if statusline_ok and cmds_ok:
         return 0

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,186 @@
+"""Daemon + thin-client integration tests (Phase B).
+
+These exercise the cheap interfaces of daemon.py / render_thin.py without
+actually fork/exec'ing a real daemon. The goal is to catch regressions in:
+
+- pidfile read/write semantics
+- meta.json freshness arithmetic
+- thin client's fast-path / fallback decision
+- statusLine recognition for `cs render` (vs bare `cs`)
+"""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from claude_statusbar import daemon as _d
+from claude_statusbar import render_thin
+from claude_statusbar.setup import (
+    _is_our_statusline,
+    _statusline_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pidfile / liveness
+# ---------------------------------------------------------------------------
+def test_read_pidfile_missing(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(_d, "_cache_dir", lambda: tmp_path)
+    assert _d.read_pidfile() is None
+
+
+def test_read_pidfile_writes_and_reads(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(_d, "_cache_dir", lambda: tmp_path)
+    (tmp_path / "daemon.pid").write_text("12345\n", encoding="utf-8")
+    assert _d.read_pidfile() == 12345
+
+
+def test_read_pidfile_handles_garbage(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(_d, "_cache_dir", lambda: tmp_path)
+    (tmp_path / "daemon.pid").write_text("not-a-number", encoding="utf-8")
+    assert _d.read_pidfile() is None
+
+
+def test_is_alive_for_self():
+    assert _d.is_alive(os.getpid()) is True
+
+
+def test_is_alive_for_dead_pid():
+    # PID 1 obviously alive; pick a very high PID unlikely to exist.
+    assert _d.is_alive(999_999_999) is False
+
+
+# ---------------------------------------------------------------------------
+# Atomic publish / meta freshness
+# ---------------------------------------------------------------------------
+def test_publish_writes_both_files(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(_d, "_cache_dir", lambda: tmp_path)
+    _d._publish("hello world")
+    assert (tmp_path / "rendered.ansi").read_text(encoding="utf-8") == "hello world\n"
+    meta = json.loads((tmp_path / "rendered.meta.json").read_text(encoding="utf-8"))
+    assert meta["pid"] == os.getpid()
+    assert meta["stale_after_seconds"] == _d.META_STALE_AFTER
+    assert abs(meta["generated_at"] - time.time()) < 5.0
+
+
+# ---------------------------------------------------------------------------
+# Thin client: freshness gate
+# ---------------------------------------------------------------------------
+def test_thin_client_is_fresh_recent_meta():
+    now = time.time()
+    assert render_thin._is_fresh({"generated_at": now, "stale_after_seconds": 5.0}) is True
+
+
+def test_thin_client_stale_meta():
+    now = time.time()
+    assert render_thin._is_fresh(
+        {"generated_at": now - 30.0, "stale_after_seconds": 5.0}
+    ) is False
+
+
+def test_thin_client_handles_missing_fields():
+    assert render_thin._is_fresh({}) is False
+    assert render_thin._is_fresh({"generated_at": "not-a-number"}) is False
+
+
+def test_thin_client_read_meta_missing(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(render_thin, "_META", tmp_path / "nope.json")
+    assert render_thin._read_meta() is None
+
+
+def test_thin_client_read_meta_corrupt(monkeypatch, tmp_path: Path):
+    p = tmp_path / "meta.json"
+    p.write_text("not json", encoding="utf-8")
+    monkeypatch.setattr(render_thin, "_META", p)
+    assert render_thin._read_meta() is None
+
+
+# ---------------------------------------------------------------------------
+# Thin client end-to-end: fresh daemon output → fast path (no core import)
+# ---------------------------------------------------------------------------
+def test_thin_client_fast_path_prints_rendered(monkeypatch, tmp_path: Path, capsys):
+    """When meta is fresh, cs render must just write rendered.ansi to stdout."""
+    rendered = tmp_path / "rendered.ansi"
+    meta = tmp_path / "rendered.meta.json"
+    rendered.write_text("FAKE STATUS LINE\n", encoding="utf-8")
+    meta.write_text(json.dumps({
+        "generated_at": time.time(),
+        "stale_after_seconds": 5.0,
+        "pid": 9999,
+    }), encoding="utf-8")
+    monkeypatch.setattr(render_thin, "_RENDERED", rendered)
+    monkeypatch.setattr(render_thin, "_META", meta)
+
+    rc = render_thin.render()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out == "FAKE STATUS LINE\n"
+
+
+def test_thin_client_fallback_when_meta_stale(monkeypatch, tmp_path: Path):
+    """Stale meta → must NOT use rendered.ansi, must call inline fallback."""
+    rendered = tmp_path / "rendered.ansi"
+    meta = tmp_path / "rendered.meta.json"
+    rendered.write_text("STALE GARBAGE\n", encoding="utf-8")
+    meta.write_text(json.dumps({
+        "generated_at": time.time() - 60.0,  # 1 minute ago
+        "stale_after_seconds": 5.0,
+    }), encoding="utf-8")
+    monkeypatch.setattr(render_thin, "_RENDERED", rendered)
+    monkeypatch.setattr(render_thin, "_META", meta)
+
+    fallback_called = []
+    spawn_called = []
+    monkeypatch.setattr(render_thin, "_fallback_inline",
+                        lambda: (fallback_called.append(True), 0)[1])
+    monkeypatch.setattr(render_thin, "_spawn_daemon_async",
+                        lambda: spawn_called.append(True))
+
+    rc = render_thin.render()
+    assert rc == 0
+    assert fallback_called == [True], "stale meta should hit inline fallback"
+    assert spawn_called == [True], "stale meta should kick off lazy daemon spawn"
+
+
+def test_thin_client_fallback_when_no_meta(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(render_thin, "_RENDERED", tmp_path / "nope.ansi")
+    monkeypatch.setattr(render_thin, "_META", tmp_path / "nope.json")
+    fallback_called = []
+    monkeypatch.setattr(render_thin, "_fallback_inline",
+                        lambda: (fallback_called.append(True), 0)[1])
+    monkeypatch.setattr(render_thin, "_spawn_daemon_async", lambda: None)
+    assert render_thin.render() == 0
+    assert fallback_called == [True]
+
+
+# ---------------------------------------------------------------------------
+# settings.json: cs render must be recognized as ours
+# ---------------------------------------------------------------------------
+def test_is_our_statusline_recognizes_cs_render():
+    assert _is_our_statusline({"type": "command", "command": "cs render"}) is True
+    assert _is_our_statusline({"type": "command", "command": "/usr/local/bin/cs render"}) is True
+
+
+def test_is_our_statusline_still_recognizes_bare_cs():
+    assert _is_our_statusline({"type": "command", "command": "cs"}) is True
+    assert _is_our_statusline({"type": "command", "command": "/Users/x/.local/bin/cs"}) is True
+
+
+def test_is_our_statusline_rejects_foreign_command():
+    assert _is_our_statusline({"type": "command", "command": "/bin/cat"}) is False
+    assert _is_our_statusline({"type": "command", "command": "starship prompt"}) is False
+
+
+def test_statusline_config_fast_appends_render():
+    cfg = _statusline_config(fast=True)
+    assert cfg["command"].endswith(" render"), \
+        f"fast mode must end with ' render', got {cfg['command']!r}"
+
+
+def test_statusline_config_default_no_render():
+    cfg = _statusline_config(fast=False)
+    assert not cfg["command"].endswith(" render")

--- a/tests/test_import_perf.py
+++ b/tests/test_import_perf.py
@@ -77,3 +77,39 @@ def test_init_module_does_not_import_metadata():
         "importlib.metadata loaded just by `import claude_statusbar` — the "
         "lazy __version__ accessor in __init__.py was bypassed."
     )
+
+
+# ---------------------------------------------------------------------------
+# Phase B: render_thin must stay tiny
+# ---------------------------------------------------------------------------
+RENDER_THIN_BANNED = {
+    # Heavy first-party modules that defeat the daemon speedup if pulled in
+    # on the fast path.
+    "claude_statusbar.core",
+    "claude_statusbar.styles",
+    "claude_statusbar.themes",
+    "claude_statusbar.progress",
+    "claude_statusbar.setup",
+    "claude_statusbar.daemon",
+    # Heavy stdlib already covered above:
+    "importlib.metadata",
+    "subprocess",
+    "shutil",
+    "argparse",
+}
+
+
+def test_render_thin_imports_stay_minimal():
+    """`cs render` (Phase B fast path) must import none of the heavy modules.
+
+    If the daemon is alive and rendered.ansi is fresh, the entire render is
+    just `read file → write to stdout`. Pulling core/styles/themes into the
+    happy path would add ~10ms per tick × 60 ticks/min = pure regression.
+    """
+    loaded = _list_imports_for("claude_statusbar.render_thin")
+    leaked = sorted(RENDER_THIN_BANNED & loaded)
+    assert not leaked, (
+        f"cs render fast-path import regression: {leaked} are loaded just "
+        f"by importing claude_statusbar.render_thin. Move them to lazy "
+        f"local imports in the fallback path only."
+    )


### PR DESCRIPTION
Second of three perf phases. Eliminates the ~30ms unavoidable Python interpreter startup that Phase A couldn't touch.

## TL;DR

| metric                | baseline  | after phase A | after phase B |
|-----------------------|-----------|---------------|---------------|
| `cs` render wall-clock | ~60-70ms | ~40-45ms      | **~20-30ms**  |
| 1Hz CPU (one core)    | ~6%       | ~4%           | **~2-3% total** |

## Architecture

\`\`\`
Claude Code  →  cs render  →  reads ~/.cache/claude-statusbar/rendered.ansi
                  ↓ (if stale: meta.generated_at > 5s)
                inline-fallback render (Phase A path) + lazy spawn daemon
                  
cs daemon start  →  long-lived Python process
                 →  every 1s: capture core.main()'s stdout
                 →  atomic write rendered.ansi + rendered.meta.json
                 →  fcntl.flock on daemon.pid (one daemon per user)
\`\`\`

### New CLI surface
- \`cs render\` — the new statusLine command. Bare-stdlib only on the happy path (pinned by import-perf test). Just \`read file → write to stdout\`.
- \`cs daemon start [--foreground] [--render-interval N]\` — spawns the daemon detached.
- \`cs daemon stop\` — SIGTERM the recorded pid, wait up to 2s for clean exit.
- \`cs daemon status\` — pid + rendered.ansi staleness, exit code 0/1/2.
- \`cs --setup --fast\` — opt-in: writes \`cs render\` to settings.json AND starts the daemon.

### Crash safety (addressing earlier review concerns)
- All writes go through the existing \`atomic_write_text\` (sibling tempfile + os.replace).
- \`fcntl.flock\` on \`daemon.pid\` prevents two daemons racing.
- Thin client's watchdog: \`meta.generated_at > 5s\` → fall back to inline render + lazy-spawn daemon. User never sees a frozen status bar.
- \`_is_our_statusline\` already strips args + path, so \`cs render\` is auto-recognized as ours (existing self-heal works) — pinned by new tests.
- Daemon's render loop sets \`_suppress_side_effects=True\` so it doesn't fire auto-update checks 60×/min.

### Backward compatibility
- Bare \`cs\` and existing inline rendering are unchanged.
- Existing users are NOT auto-migrated. They opt in via \`cs --setup --fast\`.
- \`cs --setup\` (no \`--fast\`) reverts back to bare-cs.

## Tests
- \`tests/test_daemon.py\` (new, 19 tests): pidfile read/write, liveness checks, atomic publish, thin-client freshness gate, fast-path-vs-fallback, settings.json recognition for \`cs render\`.
- \`tests/test_import_perf.py\`: new check that \`render_thin\` does NOT import core/styles/themes/progress/setup/daemon on the fast path.
- All 221 tests pass (was 202).

## Manual verification (logs in commit)
- \`cs daemon start\` → \`cs daemon status\` shows pid alive, rendered.ansi 0.5s old.
- 10x \`cs render\` runs all came in at 20-30ms wall-clock (vs 40-50ms inline).
- \`cs daemon stop\` → \`cs render\` falls back to inline (40ms) + lazy-spawns daemon → 1.5s later daemon is alive again.
- Two \`cs daemon start\` invocations: second correctly reports "already running".
- \`cs doctor\` shows daemon row with pid + freshness.

## Phase C
LaunchAgent / systemd installer for users who want the daemon auto-started on login (vs the current lazy-spawn model). Coming next.