### PR TITLE
perf(phase-c): cs daemon install — launchd / systemd auto-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,19 @@ Crash safety: if the daemon dies or freezes, `cs render` notices `rendered.meta.
 
 To revert: `cs --setup` (no `--fast`) restores the bare-`cs` legacy command.
 
+#### Optional: auto-start on login (launchd / systemd)
+
+Lazy-spawn (above) covers most cases — the daemon comes up on first `cs render`. If you want stronger guarantees (auto-start at login, OS restarts the daemon on crash, survives reboots without `cs render` needing to fire first):
+
+```bash
+cs daemon install        # installs ~/Library/LaunchAgents (macOS) or
+                          # ~/.config/systemd/user (Linux), starts the daemon
+cs daemon service        # report whether the OS-level service is registered
+cs daemon uninstall      # remove the LaunchAgent / systemd unit
+```
+
+On macOS, the LaunchAgent has `KeepAlive=true` and `ThrottleInterval=10` — kill the daemon and launchd respawns it within 10 seconds. On Linux, the systemd user unit uses `Restart=always` (you may need `loginctl enable-linger $USER` for the daemon to survive logout).
+
 ### `cs doctor` — self-diagnostic
 
 If the status bar isn't behaving the way you expect, run:

--- a/src/claude_statusbar/cli.py
+++ b/src/claude_statusbar/cli.py
@@ -134,9 +134,20 @@ def _run_daemon_subcommand(rest):
                 except ValueError:
                     pass
         return _d.run_forever(render_interval=interval)
+    if action in ("install", "uninstall", "service"):
+        from . import service as _svc
+        if action == "install":
+            ok, msg = _svc.install()
+        elif action == "uninstall":
+            ok, msg = _svc.uninstall()
+        else:  # service → status
+            ok, msg = _svc.status()
+        marker = "✓" if ok else "!"
+        print(f"{marker} {msg}")
+        return 0 if ok else 1
     print(
         f"unknown daemon action: {action!r} "
-        "(usage: cs daemon [start|stop|status])",
+        "(usage: cs daemon [start|stop|status|install|uninstall|service])",
         file=sys.stderr,
     )
     return 2

--- a/src/claude_statusbar/doctor.py
+++ b/src/claude_statusbar/doctor.py
@@ -140,6 +140,17 @@ def run() -> int:
     except Exception as e:
         _line("daemon", _dim(f"check skipped: {e}"))
 
+    # --- launchd / systemd service (Phase C) ---
+    try:
+        from . import service as _svc
+        ok, msg = _svc.status()
+        if ok:
+            _line("service", msg, ok=True)
+        else:
+            _line("service", _dim(msg))
+    except Exception as e:
+        _line("service", _dim(f"check skipped: {e}"))
+
     # --- terminal ---
     try:
         size = os.get_terminal_size()

--- a/src/claude_statusbar/service.py
+++ b/src/claude_statusbar/service.py
@@ -1,0 +1,293 @@
+"""OS-level service installer for the cs daemon (Phase C).
+
+Lazy-spawn (Phase B) is the default: the daemon comes up the first time
+``cs render`` notices stale output, and stays up as long as you don't
+``cs daemon stop`` it. That covers 99% of cases.
+
+This module is for users who want stronger guarantees: daemon auto-starts
+on login, gets restarted by the OS if it crashes, and survives reboots
+without any human action. macOS uses launchd; Linux uses systemd user
+units; Windows is unsupported (no need yet — Claude Code's primary users
+are macOS/Linux).
+
+Public API: ``install()``, ``uninstall()``, ``status()``. Each returns
+``(ok: bool, message: str)``. The ``cs daemon install`` /
+``cs daemon uninstall`` subcommands route here.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Tuple
+
+from .cache import atomic_write_text
+
+
+LAUNCHD_LABEL = "com.claude-statusbar.daemon"
+SYSTEMD_UNIT = "claude-statusbar-daemon.service"
+
+
+# ---------------------------------------------------------------------------
+# Platform detection + paths
+# ---------------------------------------------------------------------------
+def _platform() -> str:
+    """Return 'macos', 'linux', or 'unsupported'."""
+    if sys.platform == "darwin":
+        return "macos"
+    if sys.platform.startswith("linux"):
+        return "linux"
+    return "unsupported"
+
+
+def launchagents_dir() -> Path:
+    return Path.home() / "Library" / "LaunchAgents"
+
+
+def launchd_plist_path() -> Path:
+    return launchagents_dir() / f"{LAUNCHD_LABEL}.plist"
+
+
+def systemd_user_dir() -> Path:
+    """XDG-respecting systemd user unit dir."""
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "systemd" / "user"
+
+
+def systemd_unit_path() -> Path:
+    return systemd_user_dir() / SYSTEMD_UNIT
+
+
+# ---------------------------------------------------------------------------
+# Resolve `cs` binary (mirror setup.py's logic so the unit file is self-contained)
+# ---------------------------------------------------------------------------
+def _resolve_cs() -> str:
+    """Best-effort absolute path to the `cs` binary, for the unit file."""
+    cmd = shutil.which("cs") or shutil.which("cstatus") or shutil.which("claude-statusbar")
+    if cmd and Path(cmd).is_file():
+        return cmd
+    for p in (
+        Path.home() / ".local" / "bin" / "cs",
+        Path.home() / ".local" / "share" / "uv" / "tools" / "claude-statusbar" / "bin" / "cs",
+        Path.home() / ".local" / "pipx" / "venvs" / "claude-statusbar" / "bin" / "cs",
+        Path("/usr/local/bin/cs"),
+        Path("/opt/homebrew/bin/cs"),
+    ):
+        if p.is_file():
+            return str(p)
+    return "cs"
+
+
+# ---------------------------------------------------------------------------
+# macOS launchd
+# ---------------------------------------------------------------------------
+def _build_launchd_plist(cs_path: str) -> str:
+    """plist body for launchd. KeepAlive bounces a crashed daemon
+    automatically, RunAtLoad covers cold boots."""
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{LAUNCHD_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{cs_path}</string>
+        <string>daemon</string>
+        <string>_run</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>StandardOutPath</key>
+    <string>{Path.home()}/.cache/claude-statusbar/daemon.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>{Path.home()}/.cache/claude-statusbar/daemon.stderr.log</string>
+</dict>
+</plist>
+"""
+
+
+def _launchctl(*args: str) -> Tuple[int, str, str]:
+    p = subprocess.run(
+        ["launchctl", *args],
+        capture_output=True,
+        text=True,
+    )
+    return p.returncode, p.stdout, p.stderr
+
+
+def _macos_install() -> Tuple[bool, str]:
+    plist_path = launchd_plist_path()
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    body = _build_launchd_plist(_resolve_cs())
+    if not atomic_write_text(plist_path, body):
+        return False, f"Could not write {plist_path}"
+    # `launchctl bootstrap gui/$UID` is the modern way to load a user agent.
+    uid = os.getuid()
+    rc, _, err = _launchctl("bootstrap", f"gui/{uid}", str(plist_path))
+    # Already-loaded → idempotent success.
+    if rc != 0 and "already" not in err.lower() and "service already loaded" not in err.lower():
+        # Older macOS: fall back to `launchctl load`.
+        rc2, _, err2 = _launchctl("load", str(plist_path))
+        if rc2 != 0:
+            return False, (
+                f"plist written to {plist_path}, but `launchctl bootstrap` "
+                f"failed: {err.strip() or err2.strip()}. Reboot or run "
+                f"`launchctl load -w {plist_path}` manually."
+            )
+    return True, (
+        f"LaunchAgent installed at {plist_path}. The daemon will auto-start on "
+        f"login and be re-spawned by launchd if it crashes."
+    )
+
+
+def _macos_uninstall() -> Tuple[bool, str]:
+    plist_path = launchd_plist_path()
+    if not plist_path.exists():
+        return True, f"No LaunchAgent at {plist_path}; nothing to remove."
+    uid = os.getuid()
+    # Best-effort unload; we delete the file even if launchctl complains.
+    _launchctl("bootout", f"gui/{uid}/{LAUNCHD_LABEL}")
+    try:
+        plist_path.unlink()
+    except OSError as e:
+        return False, f"Could not delete {plist_path}: {e}"
+    return True, f"LaunchAgent removed ({plist_path}). Daemon may still be running — `cs daemon stop` to kill it now."
+
+
+def _macos_status() -> Tuple[bool, str]:
+    plist_path = launchd_plist_path()
+    if not plist_path.exists():
+        return False, f"not installed (no {plist_path})"
+    rc, out, _ = _launchctl("print", f"gui/{os.getuid()}/{LAUNCHD_LABEL}")
+    if rc != 0:
+        return False, f"plist exists at {plist_path} but launchd doesn't know it (try `cs daemon install` again)"
+    # Find the "state = running"-ish line.
+    state = "unknown"
+    for line in out.splitlines():
+        ls = line.strip()
+        if ls.startswith("state ="):
+            state = ls.split("=", 1)[1].strip()
+            break
+    return True, f"installed ({plist_path}), launchd state: {state}"
+
+
+# ---------------------------------------------------------------------------
+# Linux systemd user unit
+# ---------------------------------------------------------------------------
+def _build_systemd_unit(cs_path: str) -> str:
+    return f"""[Unit]
+Description=claude-statusbar render daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={cs_path} daemon _run
+Restart=always
+RestartSec=5
+StandardOutput=append:%h/.cache/claude-statusbar/daemon.stdout.log
+StandardError=append:%h/.cache/claude-statusbar/daemon.stderr.log
+
+[Install]
+WantedBy=default.target
+"""
+
+
+def _systemctl_user(*args: str) -> Tuple[int, str, str]:
+    p = subprocess.run(
+        ["systemctl", "--user", *args],
+        capture_output=True,
+        text=True,
+    )
+    return p.returncode, p.stdout, p.stderr
+
+
+def _linux_install() -> Tuple[bool, str]:
+    if shutil.which("systemctl") is None:
+        return False, (
+            "systemctl not found. systemd is required for service mode on "
+            "Linux. Use `cs daemon start` for the lazy-spawn model instead."
+        )
+    unit_path = systemd_unit_path()
+    unit_path.parent.mkdir(parents=True, exist_ok=True)
+    body = _build_systemd_unit(_resolve_cs())
+    if not atomic_write_text(unit_path, body):
+        return False, f"Could not write {unit_path}"
+    rc1, _, e1 = _systemctl_user("daemon-reload")
+    rc2, _, e2 = _systemctl_user("enable", "--now", SYSTEMD_UNIT)
+    if rc2 != 0:
+        return False, (
+            f"unit written to {unit_path}, but `systemctl --user enable --now` "
+            f"failed: {e1.strip() or e2.strip()}. Run it manually to debug."
+        )
+    return True, (
+        f"systemd user unit installed at {unit_path} and started. The daemon "
+        f"will auto-start on login. (You may need `loginctl enable-linger` for "
+        f"it to survive logout — see systemd.unit(5).)"
+    )
+
+
+def _linux_uninstall() -> Tuple[bool, str]:
+    unit_path = systemd_unit_path()
+    if not unit_path.exists():
+        return True, f"No systemd unit at {unit_path}; nothing to remove."
+    if shutil.which("systemctl"):
+        _systemctl_user("disable", "--now", SYSTEMD_UNIT)
+        _systemctl_user("daemon-reload")
+    try:
+        unit_path.unlink()
+    except OSError as e:
+        return False, f"Could not delete {unit_path}: {e}"
+    return True, f"systemd unit removed ({unit_path})."
+
+
+def _linux_status() -> Tuple[bool, str]:
+    unit_path = systemd_unit_path()
+    if not unit_path.exists():
+        return False, f"not installed (no {unit_path})"
+    if shutil.which("systemctl") is None:
+        return True, f"unit at {unit_path}, but systemctl not on PATH"
+    rc, out, _ = _systemctl_user("is-active", SYSTEMD_UNIT)
+    state = out.strip() or "unknown"
+    return rc == 0, f"installed ({unit_path}), systemd state: {state}"
+
+
+# ---------------------------------------------------------------------------
+# Public entry points (called from cli._run_daemon_subcommand)
+# ---------------------------------------------------------------------------
+def install() -> Tuple[bool, str]:
+    plat = _platform()
+    if plat == "macos":
+        return _macos_install()
+    if plat == "linux":
+        return _linux_install()
+    return False, (
+        f"OS-level service mode not supported on {sys.platform!r}. "
+        "Use `cs daemon start` for the lazy-spawn model."
+    )
+
+
+def uninstall() -> Tuple[bool, str]:
+    plat = _platform()
+    if plat == "macos":
+        return _macos_uninstall()
+    if plat == "linux":
+        return _linux_uninstall()
+    return False, f"nothing to uninstall on {sys.platform!r}"
+
+
+def status() -> Tuple[bool, str]:
+    plat = _platform()
+    if plat == "macos":
+        return _macos_status()
+    if plat == "linux":
+        return _linux_status()
+    return False, f"unsupported platform {sys.platform!r}"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,89 @@
+"""Phase C: launchd / systemd service installer.
+
+These tests focus on the file-content + path semantics of the installer.
+The actual `launchctl bootstrap` / `systemctl --user enable` calls aren't
+exercised — those need real OS state. Manual verification covers them.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from claude_statusbar import service
+
+
+def test_platform_detection():
+    plat = service._platform()
+    assert plat in {"macos", "linux", "unsupported"}
+    if sys.platform == "darwin":
+        assert plat == "macos"
+    elif sys.platform.startswith("linux"):
+        assert plat == "linux"
+
+
+def test_launchd_plist_structure():
+    body = service._build_launchd_plist("/usr/local/bin/cs")
+    assert "<?xml" in body
+    assert "<key>Label</key>" in body
+    assert f"<string>{service.LAUNCHD_LABEL}</string>" in body
+    # Critical: must invoke our daemon _run subcommand, not anything else.
+    assert "<string>/usr/local/bin/cs</string>" in body
+    assert "<string>daemon</string>" in body
+    assert "<string>_run</string>" in body
+    # KeepAlive bounces a crashed daemon — the whole point of Phase C.
+    assert "<key>KeepAlive</key>" in body
+    assert "<true/>" in body
+    assert "<key>RunAtLoad</key>" in body
+    # ThrottleInterval keeps a crash-loop from melting the CPU.
+    assert "<key>ThrottleInterval</key>" in body
+
+
+def test_systemd_unit_structure():
+    body = service._build_systemd_unit("/usr/local/bin/cs")
+    assert "[Unit]" in body
+    assert "[Service]" in body
+    assert "[Install]" in body
+    assert "ExecStart=/usr/local/bin/cs daemon _run" in body
+    # Must auto-restart on crash.
+    assert "Restart=always" in body
+    # WantedBy=default.target so it runs at user-login under systemd.
+    assert "WantedBy=default.target" in body
+
+
+def test_launchd_plist_path_uses_LaunchAgents():
+    p = service.launchd_plist_path()
+    assert p.parent == Path.home() / "Library" / "LaunchAgents"
+    assert p.name == f"{service.LAUNCHD_LABEL}.plist"
+
+
+def test_systemd_user_dir_respects_xdg(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    assert service.systemd_user_dir() == tmp_path / "systemd" / "user"
+
+
+def test_systemd_user_dir_default_when_xdg_unset(monkeypatch):
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    assert service.systemd_user_dir() == Path.home() / ".config" / "systemd" / "user"
+
+
+def test_install_unsupported_platform(monkeypatch):
+    monkeypatch.setattr(service, "_platform", lambda: "unsupported")
+    ok, msg = service.install()
+    assert ok is False
+    assert "not supported" in msg.lower()
+
+
+def test_uninstall_idempotent_when_nothing_installed(monkeypatch, tmp_path: Path):
+    """Calling uninstall when no plist/unit exists should report success."""
+    if service._platform() == "macos":
+        monkeypatch.setattr(service, "launchd_plist_path", lambda: tmp_path / "nope.plist")
+        ok, msg = service._macos_uninstall()
+    elif service._platform() == "linux":
+        monkeypatch.setattr(service, "systemd_unit_path", lambda: tmp_path / "nope.service")
+        ok, msg = service._linux_uninstall()
+    else:
+        pytest.skip(f"unsupported platform {sys.platform!r}")
+    assert ok is True
+    assert "nothing to remove" in msg.lower()


### PR DESCRIPTION
Final perf phase. Phase B's lazy-spawn already covers most cases (daemon comes up on first \`cs render\` when meta.json is stale). Phase C is for users who want stronger guarantees: auto-start on login, OS-managed crash recovery, survive reboots without \`cs render\` needing to fire first.

## New CLI surface

\`\`\`bash
cs daemon install        # writes plist (macOS) or systemd unit (Linux), starts it
cs daemon service        # report installed state + OS-side liveness
cs daemon uninstall      # remove plist/unit + bootout/disable in launchd/systemd
\`\`\`

## What gets installed

### macOS — \`~/Library/LaunchAgents/com.claude-statusbar.daemon.plist\`
- \`KeepAlive=true\` → respawns daemon on crash
- \`RunAtLoad=true\` → starts on login
- \`ThrottleInterval=10\` → crash loops can't melt the CPU
- \`ProgramArguments\` invokes \`cs daemon _run\` (the same internal subcommand Phase B already used for detached spawn — kept absolute paths everywhere so PATH-at-boot doesn't matter)
- Loaded via \`launchctl bootstrap gui/$UID\` with fallback to legacy \`launchctl load\` for older macOS.

### Linux — \`~/.config/systemd/user/claude-statusbar-daemon.service\`
- \`Restart=always\`, \`RestartSec=5\`
- \`WantedBy=default.target\` → user-login activation
- Activated via \`systemctl --user enable --now\`
- Note: surviving logout requires \`loginctl enable-linger \$USER\` (called out in the install message + README)

## Manual verification (M-series macOS)
- \`cs daemon install\` → plist written, launchd state: running, daemon pid alive
- \`kill <pid>\` → launchd respawned the daemon within ThrottleInterval (~10s)
- \`cs daemon uninstall\` → plist removed, launchd bootout, daemon SIGTERM'd cleanly

## Tests
\`tests/test_service.py\` (new, 9 tests):
- platform detection (macos/linux/unsupported)
- plist body must contain \`KeepAlive\` + \`RunAtLoad\` + \`ThrottleInterval\` + correct \`ProgramArguments\`
- systemd unit must contain \`Restart=always\` + \`WantedBy=default.target\` + \`ExecStart=...daemon _run\`
- \`launchd_plist_path()\` points at \`~/Library/LaunchAgents\`
- \`systemd_user_dir()\` respects \`XDG_CONFIG_HOME\`
- install on unsupported OS reports failure cleanly
- uninstall is idempotent when nothing's installed

\`cs doctor\` now reports both the daemon row (Phase B) and the service row (Phase C).

All 230 tests pass (was 221; +9).

## Cumulative improvement across Phase A + B + C

| metric                  | baseline  | A     | B     | C (no extra perf — adds resilience) |
|-------------------------|-----------|-------|-------|--------------------------------------|
| \`cs\` render wall-clock | 60-70ms   | 40-45ms | 20-30ms | 20-30ms |
| 1Hz CPU (one core)      | ~6%       | ~4%   | ~2-3% | ~2-3% |
| Daemon resilience       | n/a       | n/a   | lazy-spawn | OS-managed |

C doesn't add more raw speed — it gives users the option of "I never want to think about this daemon again, OS take care of it" which is the right default for power users on \`refreshInterval: 1\`.