### PR TITLE
fix(phase-d): codex review fixes + 1Hz upsell hint

### DIFF
--- a/src/claude_statusbar/core.py
+++ b/src/claude_statusbar/core.py
@@ -979,6 +979,12 @@ def get_cache_age_text(ttl_seconds: int = 300) -> str:
 
     if age_s > ttl_seconds:
         return "COLD"
+    # Clock-skew clamp: if the transcript timestamp is in the future (NTP
+    # correction or sandbox time-warp), `age_s` goes negative and produces
+    # nonsense like "-1m" / "-30s". Floor to 0 so the segment renders as
+    # "cache 0s" until the wall clock catches up.
+    if age_s < 0:
+        age_s = 0
     mins = int(age_s) // 60
     secs = int(age_s) % 60
     if mins > 0:

--- a/src/claude_statusbar/daemon.py
+++ b/src/claude_statusbar/daemon.py
@@ -143,6 +143,39 @@ def is_alive(pid: int) -> bool:
         return False
 
 
+def _process_is_our_daemon(pid: int) -> bool:
+    """Verify the PID actually belongs to *our* daemon, not a recycled PID.
+
+    Linux: read /proc/<pid>/cmdline directly (cheap, no fork).
+    macOS / fallback: shell out to `ps -o command= -p <pid>` (~10ms — only
+    runs on stop/install paths, never on the per-render hot path).
+
+    Returns False on any error (better to assume not-ours and skip than to
+    accidentally SIGTERM an unrelated user process).
+    """
+    proc_path = f"/proc/{pid}/cmdline"
+    try:
+        with open(proc_path, "rb") as f:
+            cmdline = f.read().decode("utf-8", errors="replace")
+        return "claude_statusbar" in cmdline and "daemon" in cmdline
+    except OSError:
+        pass
+    # Non-Linux fallback.
+    try:
+        import subprocess
+        out = subprocess.run(
+            ["ps", "-o", "command=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        )
+        if out.returncode != 0:
+            return False
+        return "claude_statusbar" in out.stdout and "daemon" in out.stdout
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Render — capture core.main()'s stdout into a string
 # ---------------------------------------------------------------------------
@@ -214,6 +247,11 @@ def run_forever(render_interval: float = DEFAULT_RENDER_INTERVAL) -> int:
     "heavy tick" — every render tick that triggers a refresh hits the
     cache, only the periodic invalidation pays the heavy cost.
     """
+    # Reset module-level shutdown flag so an in-process restart (after a
+    # previous SIGTERM call set _running=False) doesn't exit immediately.
+    global _running
+    _running = True
+
     if not _acquire_pidfile():
         existing = read_pidfile()
         sys.stderr.write(
@@ -255,6 +293,9 @@ def cmd_status() -> int:
         print("daemon: not running (no pidfile)")
         return 1
     alive = is_alive(pid)
+    if alive and not _process_is_our_daemon(pid):
+        print(f"daemon: pid {pid} alive but is not our daemon (PID was reused). Run `cs daemon stop` to clear stale pidfile.")
+        return 1
     print(f"daemon: pid {pid} {'alive' if alive else 'STALE pidfile (process gone)'}")
     if not alive:
         return 1
@@ -284,6 +325,14 @@ def cmd_stop() -> int:
         except OSError:
             pass
         return 0
+    # PID reuse defense: never SIGTERM a process we don't recognize as ours.
+    if not _process_is_our_daemon(pid):
+        print(
+            f"daemon: pid {pid} is alive but is NOT our daemon (PID reused). "
+            f"Refusing to SIGTERM. Manually remove {pid_path()} if you're sure.",
+            file=sys.stderr,
+        )
+        return 1
     try:
         os.kill(pid, signal.SIGTERM)
     except OSError as e:
@@ -302,9 +351,16 @@ def cmd_stop() -> int:
 def cmd_start(detach: bool = True, render_interval: float = DEFAULT_RENDER_INTERVAL) -> int:
     """`cs daemon start` — fork a detached daemon, or run inline if --foreground."""
     pid = read_pidfile()
-    if pid is not None and is_alive(pid):
+    if pid is not None and is_alive(pid) and _process_is_our_daemon(pid):
         print(f"daemon: already running (pid {pid})")
         return 0
+    # Stale pidfile (PID reused, or daemon SIGKILL'd without cleanup): drop
+    # it so flock acquisition succeeds for the new daemon.
+    if pid is not None:
+        try:
+            pid_path().unlink()
+        except OSError:
+            pass
     if not detach:
         # Run in current process (used for testing + `--foreground`).
         return run_forever(render_interval=render_interval)
@@ -338,7 +394,7 @@ def spawn_if_dead(render_interval: float = DEFAULT_RENDER_INTERVAL) -> bool:
     False if spawn failed silently.
     """
     pid = read_pidfile()
-    if pid is not None and is_alive(pid):
+    if pid is not None and is_alive(pid) and _process_is_our_daemon(pid):
         return True
     try:
         import subprocess

--- a/src/claude_statusbar/doctor.py
+++ b/src/claude_statusbar/doctor.py
@@ -85,11 +85,23 @@ def run() -> int:
         sl = settings.get("statusLine") if isinstance(settings, dict) else None
         if isinstance(sl, dict) and sl.get("command"):
             cmd = sl["command"]
-            from .setup import _is_our_statusline
+            from .setup import _is_our_statusline, _existing_uses_render
             ours = _is_our_statusline(sl)
             _line("statusLine entry",
                   f"{cmd}  {_green('(ours)') if ours else _red('(not ours)')}",
                   ok=ours)
+            # Phase B/C upsell: at refreshInterval=1 the inline command
+            # burns ~4% CPU continuously; fast mode drops it to ~1%.
+            try:
+                ri = sl.get("refreshInterval")
+                if (isinstance(ri, (int, float)) and ri <= 2 and ours
+                        and not _existing_uses_render(sl)):
+                    _line("perf hint",
+                          _dim(f"refreshInterval={ri}s with inline `cs`. "
+                               f"Run `cs --setup --fast` for ~5x lower CPU "
+                               f"(daemon mode). See README → Fast mode."))
+            except (TypeError, ValueError):
+                pass
         else:
             _line("statusLine entry",
                   _red("missing — run: cs --setup"), ok=False)

--- a/src/claude_statusbar/render_thin.py
+++ b/src/claude_statusbar/render_thin.py
@@ -35,13 +35,23 @@ def _read_meta() -> dict | None:
 
 
 def _is_fresh(meta: dict) -> bool:
-    """Daemon's last write must be within stale_after_seconds of now."""
+    """Daemon's last write must be within stale_after_seconds of now.
+
+    Clock skew defense: if `generated_at` is in the future (NTP correction,
+    container time-warp, user setting clock backward), treat the entry as
+    STALE. Otherwise a wall-clock jump backward would freeze stale daemon
+    output for the duration of the skew.
+    """
     try:
         generated_at = float(meta.get("generated_at", 0))
         stale_after = float(meta.get("stale_after_seconds", _STALE_AFTER_DEFAULT))
     except (TypeError, ValueError):
         return False
-    return (time.time() - generated_at) <= stale_after
+    delta = time.time() - generated_at
+    if delta < 0:
+        # Future timestamp — treat as stale, fall back + re-spawn.
+        return False
+    return delta <= stale_after
 
 
 def _spawn_daemon_async() -> None:

--- a/src/claude_statusbar/service.py
+++ b/src/claude_statusbar/service.py
@@ -18,17 +18,20 @@ Public API: ``install()``, ``uninstall()``, ``status()``. Each returns
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 from typing import Tuple
+from xml.sax.saxutils import escape as _xml_escape
 
 from .cache import atomic_write_text
 
 
 LAUNCHD_LABEL = "com.claude-statusbar.daemon"
 SYSTEMD_UNIT = "claude-statusbar-daemon.service"
+_SUBPROCESS_TIMEOUT = 10.0  # launchctl/systemctl should never take longer
 
 
 # ---------------------------------------------------------------------------
@@ -66,20 +69,13 @@ def systemd_unit_path() -> Path:
 # Resolve `cs` binary (mirror setup.py's logic so the unit file is self-contained)
 # ---------------------------------------------------------------------------
 def _resolve_cs() -> str:
-    """Best-effort absolute path to the `cs` binary, for the unit file."""
-    cmd = shutil.which("cs") or shutil.which("cstatus") or shutil.which("claude-statusbar")
-    if cmd and Path(cmd).is_file():
-        return cmd
-    for p in (
-        Path.home() / ".local" / "bin" / "cs",
-        Path.home() / ".local" / "share" / "uv" / "tools" / "claude-statusbar" / "bin" / "cs",
-        Path.home() / ".local" / "pipx" / "venvs" / "claude-statusbar" / "bin" / "cs",
-        Path("/usr/local/bin/cs"),
-        Path("/opt/homebrew/bin/cs"),
-    ):
-        if p.is_file():
-            return str(p)
-    return "cs"
+    """Best-effort absolute path to the `cs` binary, for the unit file.
+
+    Delegates to setup._resolve_cs_command() so the lookup logic doesn't
+    drift between settings.json writers and OS service installers.
+    """
+    from .setup import _resolve_cs_command
+    return _resolve_cs_command()
 
 
 # ---------------------------------------------------------------------------
@@ -87,7 +83,14 @@ def _resolve_cs() -> str:
 # ---------------------------------------------------------------------------
 def _build_launchd_plist(cs_path: str) -> str:
     """plist body for launchd. KeepAlive bounces a crashed daemon
-    automatically, RunAtLoad covers cold boots."""
+    automatically, RunAtLoad covers cold boots.
+
+    All path fields are XML-escaped — a $HOME containing `&`, `<`, or `>`
+    (rare but possible) would otherwise produce malformed plist XML that
+    launchctl rejects.
+    """
+    cs_esc = _xml_escape(cs_path)
+    home_esc = _xml_escape(str(Path.home()))
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -96,7 +99,7 @@ def _build_launchd_plist(cs_path: str) -> str:
     <string>{LAUNCHD_LABEL}</string>
     <key>ProgramArguments</key>
     <array>
-        <string>{cs_path}</string>
+        <string>{cs_esc}</string>
         <string>daemon</string>
         <string>_run</string>
     </array>
@@ -107,20 +110,26 @@ def _build_launchd_plist(cs_path: str) -> str:
     <key>ThrottleInterval</key>
     <integer>10</integer>
     <key>StandardOutPath</key>
-    <string>{Path.home()}/.cache/claude-statusbar/daemon.stdout.log</string>
+    <string>{home_esc}/.cache/claude-statusbar/daemon.stdout.log</string>
     <key>StandardErrorPath</key>
-    <string>{Path.home()}/.cache/claude-statusbar/daemon.stderr.log</string>
+    <string>{home_esc}/.cache/claude-statusbar/daemon.stderr.log</string>
 </dict>
 </plist>
 """
 
 
 def _launchctl(*args: str) -> Tuple[int, str, str]:
-    p = subprocess.run(
-        ["launchctl", *args],
-        capture_output=True,
-        text=True,
-    )
+    """Run `launchctl <args>` with a hard timeout — never hang `cs daemon
+    install` if launchd is wedged."""
+    try:
+        p = subprocess.run(
+            ["launchctl", *args],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return 124, "", f"launchctl {' '.join(args)} timed out after {_SUBPROCESS_TIMEOUT}s"
     return p.returncode, p.stdout, p.stderr
 
 
@@ -184,13 +193,16 @@ def _macos_status() -> Tuple[bool, str]:
 # Linux systemd user unit
 # ---------------------------------------------------------------------------
 def _build_systemd_unit(cs_path: str) -> str:
+    """systemd user unit. ExecStart is shell-quoted so paths with spaces
+    or unit-special characters survive systemd's parser."""
+    cs_quoted = shlex.quote(cs_path)
     return f"""[Unit]
 Description=claude-statusbar render daemon
 After=network.target
 
 [Service]
 Type=simple
-ExecStart={cs_path} daemon _run
+ExecStart={cs_quoted} daemon _run
 Restart=always
 RestartSec=5
 StandardOutput=append:%h/.cache/claude-statusbar/daemon.stdout.log
@@ -202,11 +214,16 @@ WantedBy=default.target
 
 
 def _systemctl_user(*args: str) -> Tuple[int, str, str]:
-    p = subprocess.run(
-        ["systemctl", "--user", *args],
-        capture_output=True,
-        text=True,
-    )
+    """Run `systemctl --user <args>` with a hard timeout."""
+    try:
+        p = subprocess.run(
+            ["systemctl", "--user", *args],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return 124, "", f"systemctl --user {' '.join(args)} timed out after {_SUBPROCESS_TIMEOUT}s"
     return p.returncode, p.stdout, p.stderr
 
 

--- a/src/claude_statusbar/setup.py
+++ b/src/claude_statusbar/setup.py
@@ -107,25 +107,45 @@ def is_statusline_configured() -> bool:
     return _is_our_statusline(settings.get("statusLine"))
 
 
+def _existing_uses_render(existing) -> bool:
+    """True if the user's current statusLine command is `cs render`-style.
+
+    Used by the daily auto-repair path to preserve the user's choice of fast
+    vs inline mode — without this check we'd silently downgrade a fast-mode
+    user back to bare `cs` because `_statusline_config()` defaults to
+    fast=False.
+    """
+    if not isinstance(existing, dict):
+        return False
+    cmd = existing.get("command")
+    if not isinstance(cmd, str):
+        return False
+    parts = cmd.strip().split()
+    return len(parts) >= 2 and parts[1] == "render"
+
+
 def ensure_statusline_configured(fast: bool = False) -> Tuple[bool, str]:
     """Silently ensure settings.json has *our* statusLine config.
 
     Behavior:
-      - missing       → write our config
+      - missing       → write our config (honors `fast` arg)
       - foreign cmd   → leave alone (don't overwrite another tool's setup)
-      - our cmd, stale path (different `command`) → refresh path
+      - our cmd, stale path → refresh, *preserving* the user's existing
+        fast/inline choice (so the daily auto-repair doesn't downgrade
+        a user who explicitly opted into `cs --setup --fast`).
       - our cmd, current → no-op
 
-    `fast=True` writes the Phase B ``cs render`` command instead of bare
-    ``cs``. Both forms pass _is_our_statusline (basename check).
+    `fast=True` only forces the write to `cs render`. `fast=False` does
+    NOT force a downgrade — it just means "if you have to write fresh,
+    pick the inline form". Existing fast-mode entries are left alone.
 
     Returns (changed, message).
     """
     settings = _read_settings()
     existing = settings.get("statusLine")
-    desired  = _statusline_config(fast=fast)
 
     if existing is None:
+        desired = _statusline_config(fast=fast)
         settings["statusLine"] = desired
         if _write_settings(settings):
             return True, f"Added statusLine config to {SETTINGS_PATH}"
@@ -141,7 +161,11 @@ def ensure_statusline_configured(fast: bool = False) -> Tuple[bool, str]:
             f"manually if you want claude-statusbar."
         )
 
-    # Ours, but possibly outdated path → refresh if it changed.
+    # Ours already. Compute desired command preserving fast mode if the user
+    # currently uses it (so the daily auto-repair never downgrades them).
+    effective_fast = fast or _existing_uses_render(existing)
+    desired = _statusline_config(fast=effective_fast)
+
     if existing.get("command") != desired["command"]:
         settings["statusLine"] = desired
         if _write_settings(settings):

--- a/tests/test_cache_age.py
+++ b/tests/test_cache_age.py
@@ -201,6 +201,17 @@ def test_cache_text_empty_when_no_transcript_path(tmp_path: Path, monkeypatch):
     assert core.get_cache_age_text() == ""
 
 
+def test_cache_text_clamps_future_timestamp(tmp_path: Path, monkeypatch):
+    """Clock-skew defense: a transcript timestamp in the future must NOT
+    produce nonsense output like 'cache -1m' or '-30s'. Floor to 0."""
+    transcript = tmp_path / "t.jsonl"
+    future = datetime.now(timezone.utc) + timedelta(seconds=120)
+    _write_jsonl(transcript, [{"type": "assistant", "timestamp": future.isoformat()}])
+    _install_fake_cache(monkeypatch, tmp_path, {"transcript_path": str(transcript)})
+    out = core.get_cache_age_text()
+    assert out == "0s", f"future timestamp must clamp to '0s', got {out!r}"
+
+
 def test_cache_text_respects_custom_ttl(tmp_path: Path, monkeypatch):
     """Users on the 1h Anthropic cache pass ttl_seconds=3600; entries between
     300s and 3600s should still report warm, not COLD."""

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -184,3 +184,128 @@ def test_statusline_config_fast_appends_render():
 def test_statusline_config_default_no_render():
     cfg = _statusline_config(fast=False)
     assert not cfg["command"].endswith(" render")
+
+
+# ---------------------------------------------------------------------------
+# Codex review fixes
+# ---------------------------------------------------------------------------
+def test_thin_client_treats_future_timestamp_as_stale():
+    """Clock skew defense: generated_at in the future must NOT be 'fresh'.
+
+    Without this, an NTP backward-correction freezes stale daemon output
+    until wall clock catches up.
+    """
+    future = time.time() + 60.0  # 1 minute in the future
+    assert render_thin._is_fresh(
+        {"generated_at": future, "stale_after_seconds": 5.0}
+    ) is False
+
+
+def test_running_global_is_reset_per_run_forever_call(monkeypatch, tmp_path: Path):
+    """An in-process restart (after a previous SIGTERM cleared _running)
+    must NOT exit immediately on the next run_forever() call.
+
+    We don't actually loop here — we just verify the flag gets reset.
+    """
+    monkeypatch.setattr(_d, "_cache_dir", lambda: tmp_path)
+    monkeypatch.setattr(_d, "_render_once", lambda: None)  # nothing to publish
+
+    _d._running = False  # simulate previous shutdown
+    # Patch acquire to fail immediately so run_forever returns without
+    # actually entering the sleep loop. We're only checking the reset.
+    monkeypatch.setattr(_d, "_acquire_pidfile", lambda: False)
+    rc = _d.run_forever(render_interval=0.01)
+    assert rc == 1  # acquire failed
+    assert _d._running is True, (
+        "run_forever() must reset _running=True at entry; otherwise the next "
+        "in-process daemon start exits before doing any work"
+    )
+
+
+def test_existing_uses_render_detects_fast_mode():
+    from claude_statusbar.setup import _existing_uses_render
+    assert _existing_uses_render({"command": "cs render"}) is True
+    assert _existing_uses_render({"command": "/usr/local/bin/cs render"}) is True
+    assert _existing_uses_render({"command": "cs"}) is False
+    assert _existing_uses_render({"command": "/usr/local/bin/cs"}) is False
+    assert _existing_uses_render({}) is False
+    assert _existing_uses_render(None) is False
+
+
+def test_ensure_statusline_preserves_fast_mode(tmp_path: Path, monkeypatch):
+    """MUST-FIX from codex review: the daily auto-repair (default fast=False)
+    must NOT downgrade a user who already opted into `cs render`."""
+    from claude_statusbar import setup as setup_mod
+    settings = tmp_path / "settings.json"
+    monkeypatch.setattr(setup_mod, "SETTINGS_PATH", settings)
+    # User already chose fast mode previously.
+    settings.write_text(json.dumps({
+        "statusLine": {"type": "command", "command": "/abs/path/cs render"},
+    }), encoding="utf-8")
+
+    # Daily auto-repair tick — default fast=False.
+    changed, message = setup_mod.ensure_statusline_configured(fast=False)
+
+    # Read what's there now.
+    after = json.loads(settings.read_text(encoding="utf-8"))
+    new_cmd = after["statusLine"]["command"]
+    assert new_cmd.endswith(" render"), (
+        f"daily auto-repair downgraded fast mode! command is now {new_cmd!r}. "
+        f"changed={changed}, message={message!r}"
+    )
+
+
+def test_render_once_captures_stdout(monkeypatch, tmp_path: Path):
+    """Daemon's _render_once must capture core.main()'s stdout into a string.
+
+    If core.main ever stops printing (e.g., switches to logging), the daemon
+    would silently produce empty output. This test pins the contract.
+    """
+    monkeypatch.setattr(_d, "_cache_dir", lambda: tmp_path)
+    (tmp_path / "last_stdin.json").write_text("{}", encoding="utf-8")
+
+    captured_kwargs = {}
+
+    def fake_core_main(**kwargs):
+        captured_kwargs.update(kwargs)
+        sys.stdout.write("FAKE RENDERED LINE")
+
+    # Patch the core.main symbol the daemon imports lazily.
+    import claude_statusbar.core as core_mod
+    monkeypatch.setattr(core_mod, "main", fake_core_main)
+
+    out = _d._render_once()
+    assert out == "FAKE RENDERED LINE", f"capture failed; got {out!r}"
+    assert captured_kwargs.get("_suppress_side_effects") is True, (
+        "daemon must call core.main with _suppress_side_effects=True so it "
+        "doesn't fire auto-update / settings-repair 60×/min"
+    )
+
+
+def test_suppress_side_effects_skips_update_check(monkeypatch, tmp_path: Path):
+    """_suppress_side_effects=True must skip both check_for_updates and
+    _maybe_ensure_statusline (the daemon path runs them on its own cadence)."""
+    import claude_statusbar.core as core_mod
+    update_calls = []
+    statusline_calls = []
+    monkeypatch.setattr(core_mod, "check_for_updates",
+                        lambda *a, **kw: update_calls.append(True))
+    monkeypatch.setattr(core_mod, "_maybe_ensure_statusline",
+                        lambda *a, **kw: statusline_calls.append(True))
+
+    # Pipe a minimal stdin payload.
+    monkeypatch.setattr(sys, "stdin", io.StringIO("{}"))
+    try:
+        core_mod.main(_suppress_side_effects=True)
+    except Exception:
+        # The render path may fail because we mocked things — that's OK.
+        # We're only checking the side-effect guard here.
+        pass
+    assert update_calls == [], "_suppress_side_effects must skip check_for_updates"
+    assert statusline_calls == [], (
+        "_suppress_side_effects must skip _maybe_ensure_statusline"
+    )
+
+
+# Helper imports for the side-effects test
+import io  # noqa: E402

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -75,6 +75,27 @@ def test_install_unsupported_platform(monkeypatch):
     assert "not supported" in msg.lower()
 
 
+def test_plist_body_parses_as_valid_xml():
+    """A nice-to-have but cheap insurance: plist text must be parseable XML.
+
+    Unescaped path characters (& < >) in $HOME would silently produce
+    malformed XML that launchctl rejects. The xml.sax.saxutils.escape
+    fix means even paths with `&` survive.
+    """
+    import xml.etree.ElementTree as ET
+    body = service._build_launchd_plist("/path/with/&-and-<-and->")
+    # Must not raise.
+    root = ET.fromstring(body)
+    assert root.tag == "plist"
+
+
+def test_systemd_exec_start_quotes_paths_with_spaces():
+    """A path with spaces must be shell-quoted in ExecStart."""
+    body = service._build_systemd_unit("/path with spaces/cs")
+    # shlex.quote wraps in single quotes; verify the path survived intact.
+    assert "ExecStart='/path with spaces/cs' daemon _run" in body
+
+
 def test_uninstall_idempotent_when_nothing_installed(monkeypatch, tmp_path: Path):
     """Calling uninstall when no plist/unit exists should report success."""
     if service._platform() == "macos":


### PR DESCRIPTION
Addresses every must-fix and should-fix from the post-Phase-C codex review, plus the 1Hz upsell hint we discussed.

## MUST-FIX
- **`ensure_statusline_configured()` no longer downgrades fast-mode users.** The daily auto-repair tick calls with default `fast=False`, which used to compute `desired = "cs"` and silently overwrite a user's `cs render` choice on every daily tick. Now: if the existing entry already uses `cs render`, the refresh path preserves it. Explicit `fast=True` still forces upgrade. Regression test added.

## SHOULD-FIX
- **Clock skew defense.** `render_thin._is_fresh` treats future `generated_at` as STALE (otherwise NTP backward-correction freezes daemon output until wall clock catches up). `get_cache_age_text` floors negative ages to `0` instead of rendering `cache -1m`.
- **PID-reuse defense.** New `_process_is_our_daemon(pid)` reads `/proc/<pid>/cmdline` (Linux) or `ps -o command= -p <pid>` (macOS) to verify a recycled PID isn't accidentally treated as our daemon. `cmd_stop` refuses to SIGTERM unrecognized processes; `cmd_start` and `spawn_if_dead` drop the stale pidfile so the new daemon can acquire `flock` cleanly.
- **Subprocess timeouts in `service.py`.** All `launchctl` / `systemctl --user` calls now have `timeout=10s` so a wedged service-management subsystem can't hang \`cs daemon install\` forever.
- **plist XML escape.** Path values now go through `xml.sax.saxutils.escape` so a `\$HOME` containing `&` / `<` / `>` no longer produces malformed plist that launchctl rejects.
- **systemd `ExecStart` shell-quote.** Paths with spaces or unit-special characters survive systemd's parser via `shlex.quote`.
- **`_resolve_cs()` drift removed.** `service.py` now delegates to `setup._resolve_cs_command` instead of duplicating the logic.
- **`_running` global reset.** `run_forever()` resets the module-level shutdown flag at entry so an in-process restart (after a previous SIGTERM cleared it) actually loops.

## NEW — 1Hz upsell hint
\`cs doctor\` now detects \`refreshInterval <= 2\` with bare-\`cs\` statusLine and prints a one-line hint recommending \`cs --setup --fast\`. Quiet for users already on fast mode or with longer intervals — purely additive.

## Tests
+9 cases, total 239 passing (was 230):
- Future timestamp → cache_age clamps to 0
- Future generated_at → meta marked stale
- `_running` reset per `run_forever` entry
- `_existing_uses_render` detects fast-mode entries
- ensure_statusline preserves fast mode under default \`fast=False\` (the must-fix regression test)
- `_render_once` captures stdout via redirect_stdout AND passes `_suppress_side_effects=True`
- `_suppress_side_effects=True` actually suppresses both check_for_updates and _maybe_ensure_statusline
- plist body parses as valid XML even with `&` in paths
- systemd ExecStart shell-quotes paths with spaces

## Manual verification
- \`cs doctor\` shows the perf hint correctly when refreshInterval=1 + bare cs.
- \`cs daemon start\` → \`cs daemon stop\` works (PID-reuse defense doesn't break the happy path).
- \`cs daemon install\` → \`cs daemon uninstall\` round-trip clean.

Nice-to-haves intentionally deferred: \`loginctl enable-linger\` auto-call (better as opt-in flag than silent system change), spawn_if_dead burst race (flock handles it; only cost is brief Popen × 2), \`launchctl bootstrap\` deprecation in macOS 15+ (unverified, would need real device test).