### PR TITLE
fix: thin client forwards stdin so daemon sees fresh rate_limits

### DIFF
--- a/src/claude_statusbar/render_thin.py
+++ b/src/claude_statusbar/render_thin.py
@@ -6,6 +6,12 @@ output and print it. If the daemon is dead or its output is stale, fall
 back transparently to the inline render path so the user never sees a
 frozen or empty status line.
 
+The thin client also forwards Claude Code's stdin payload to
+``~/.cache/claude-statusbar/last_stdin.json`` so the daemon sees fresh
+``rate_limits`` / model / transcript_path on its next tick. Without this,
+the daemon would keep re-rendering whatever snapshot was captured the
+last time the inline path ran — token counters and 7d% would freeze.
+
 Imports kept to bare stdlib (json, os, sys, time, pathlib) so the
 import-time floor stays minimal. Heavier modules (core, styles, themes)
 are deferred to the fallback path only.
@@ -54,6 +60,55 @@ def _is_fresh(meta: dict) -> bool:
     return delta <= stale_after
 
 
+_LAST_STDIN_CACHE = _CACHE_DIR / "last_stdin.json"
+
+
+def _consume_stdin() -> bytes | None:
+    """Read Claude Code's stdin payload (bytes) and return it.
+
+    Returns None if stdin is interactive or empty. Caller is responsible
+    for both (a) writing it to last_stdin.json so the daemon sees it on
+    the next tick, and (b) replaying it into sys.stdin if the inline
+    fallback path needs to consume it.
+    """
+    try:
+        if sys.stdin.isatty():
+            return None
+    except (OSError, ValueError):
+        return None
+    try:
+        data = sys.stdin.buffer.read()
+    except (OSError, AttributeError):
+        return None
+    return data or None
+
+
+def _persist_stdin_bytes(data: bytes) -> None:
+    """Atomic write of raw bytes to last_stdin.json. No JSON parse — the
+    daemon validates on its next tick. ~1ms cost, never fatal.
+
+    Why we MUST do this: Claude Code injects the *current* model +
+    rate_limits + transcript path on every statusline invocation. The
+    daemon re-reads last_stdin.json to pick up changes. Without this
+    forwarding step, the daemon would be permanently stuck on whatever
+    snapshot was captured the last time `core.main()` ran — token
+    counters and 7d% would freeze the moment fast-mode was enabled.
+    """
+    try:
+        _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        # Atomic: sibling tempfile + rename. Same pattern as
+        # cache.atomic_write_text but inlined to avoid pulling cache.py
+        # (and its imports) on the fast path.
+        tmp = _LAST_STDIN_CACHE.with_suffix(".json.thin.tmp")
+        with open(tmp, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, _LAST_STDIN_CACHE)
+    except OSError:
+        pass
+
+
 def _spawn_daemon_async() -> None:
     """Best-effort spawn of cs daemon in a detached child process.
 
@@ -80,8 +135,15 @@ def render() -> int:
 
     Returns the exit code; mirrors how the legacy `cs` invocation behaved.
     """
-    # Read-and-feel-cheap fast path: if daemon's output is fresh, just
-    # cat it to stdout and return. No core/styles/themes import.
+    # Capture Claude Code's stdin payload first. Both paths need it:
+    #   - fast path: write to last_stdin.json so daemon's next tick is fresh
+    #   - fallback: same write + replay into sys.stdin for core.main()
+    payload = _consume_stdin()
+    if payload is not None:
+        _persist_stdin_bytes(payload)
+
+    # Fast path: if daemon's output is fresh, cat the file and return.
+    # No core/styles/themes import.
     meta = _read_meta()
     if meta is not None and _is_fresh(meta):
         try:
@@ -92,8 +154,14 @@ def render() -> int:
             # Fall through to inline.
             pass
 
-    # Slow path: render inline AND kick off a daemon spawn so the *next*
+    # Fallback: render inline AND kick off a daemon spawn so the next
     # tick is fast. We don't wait for the daemon to come up — the user's
     # status line shows the inline-rendered string this tick.
     _spawn_daemon_async()
+    if payload is not None:
+        # core.main() reads sys.stdin via parse_stdin_data(); replay the
+        # bytes we already consumed so it sees the same payload Claude Code
+        # sent us.
+        import io
+        sys.stdin = io.StringIO(payload.decode("utf-8", errors="replace"))
     return _fallback_inline()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -114,11 +114,37 @@ def test_thin_client_fast_path_prints_rendered(monkeypatch, tmp_path: Path, caps
     }), encoding="utf-8")
     monkeypatch.setattr(render_thin, "_RENDERED", rendered)
     monkeypatch.setattr(render_thin, "_META", meta)
+    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: None)
 
     rc = render_thin.render()
     out = capsys.readouterr().out
     assert rc == 0
     assert out == "FAKE STATUS LINE\n"
+
+
+def test_thin_client_forwards_stdin_to_cache(monkeypatch, tmp_path: Path, capsys):
+    """Critical Phase B regression: the thin client MUST persist stdin so
+    the daemon sees fresh rate_limits on its next tick. Without this the
+    7d% / 5h% counters freeze the moment fast-mode is enabled."""
+    rendered = tmp_path / "rendered.ansi"
+    meta = tmp_path / "rendered.meta.json"
+    cache = tmp_path / "last_stdin.json"
+    rendered.write_text("X\n", encoding="utf-8")
+    meta.write_text(json.dumps({
+        "generated_at": time.time(),
+        "stale_after_seconds": 5.0,
+    }), encoding="utf-8")
+    monkeypatch.setattr(render_thin, "_RENDERED", rendered)
+    monkeypatch.setattr(render_thin, "_META", meta)
+    monkeypatch.setattr(render_thin, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(render_thin, "_LAST_STDIN_CACHE", cache)
+
+    fresh_payload = b'{"rate_limits": {"seven_day": {"used_percentage": 79}}}'
+    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: fresh_payload)
+
+    render_thin.render()
+    assert cache.exists(), "thin client must write stdin to last_stdin.json"
+    assert cache.read_bytes() == fresh_payload
 
 
 def test_thin_client_fallback_when_meta_stale(monkeypatch, tmp_path: Path):
@@ -132,6 +158,7 @@ def test_thin_client_fallback_when_meta_stale(monkeypatch, tmp_path: Path):
     }), encoding="utf-8")
     monkeypatch.setattr(render_thin, "_RENDERED", rendered)
     monkeypatch.setattr(render_thin, "_META", meta)
+    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: None)
 
     fallback_called = []
     spawn_called = []
@@ -149,12 +176,35 @@ def test_thin_client_fallback_when_meta_stale(monkeypatch, tmp_path: Path):
 def test_thin_client_fallback_when_no_meta(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(render_thin, "_RENDERED", tmp_path / "nope.ansi")
     monkeypatch.setattr(render_thin, "_META", tmp_path / "nope.json")
+    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: None)
     fallback_called = []
     monkeypatch.setattr(render_thin, "_fallback_inline",
                         lambda: (fallback_called.append(True), 0)[1])
     monkeypatch.setattr(render_thin, "_spawn_daemon_async", lambda: None)
     assert render_thin.render() == 0
     assert fallback_called == [True]
+
+
+def test_thin_client_fallback_replays_stdin_for_core_main(monkeypatch, tmp_path: Path):
+    """When falling back to inline render, the captured stdin bytes must be
+    replayed into sys.stdin so core.main()'s parse_stdin_data() sees them."""
+    monkeypatch.setattr(render_thin, "_RENDERED", tmp_path / "nope.ansi")
+    monkeypatch.setattr(render_thin, "_META", tmp_path / "nope.json")
+    monkeypatch.setattr(render_thin, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(render_thin, "_LAST_STDIN_CACHE", tmp_path / "ls.json")
+    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: b'{"hello": "world"}')
+    monkeypatch.setattr(render_thin, "_spawn_daemon_async", lambda: None)
+
+    seen = {}
+    def fake_inline():
+        seen["stdin"] = sys.stdin.read()
+        return 0
+    monkeypatch.setattr(render_thin, "_fallback_inline", fake_inline)
+
+    render_thin.render()
+    assert seen["stdin"] == '{"hello": "world"}', (
+        f"fallback path must see replayed stdin; got {seen.get('stdin')!r}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bug
Reported live: status bar shows 7d=40% while Anthropic dashboard shows 79%. Counters frozen the moment user enables fast mode.

## Root cause
`cs render` reads `rendered.ansi` + prints + exits without ever consuming Claude Code's stdin payload. `last_stdin.json` is therefore NEVER updated under fast mode — the daemon keeps re-rendering whatever snapshot was captured the last time `core.main()` ran (typically the inline render right before the user enabled fast mode).

## Fix
Thin client now:
1. `_consume_stdin()` reads Claude Code's payload bytes once
2. `_persist_stdin_bytes()` atomically writes them to `last_stdin.json` (no JSON parse on the fast path — daemon validates on next tick)
3. Fast-path: serves daemon's pre-rendered output (unchanged)
4. Fallback path: replays the consumed bytes into `sys.stdin` via `io.StringIO` so `core.main()`'s `parse_stdin_data()` still sees them

## End-to-end behavior after fix
1. Claude Code calls `cs render` with fresh stdin (e.g. 7d=85%)
2. Thin client persists stdin → `last_stdin.json` (~1ms, atomic)
3. Thin client serves daemon's pre-rendered output (~3ms)
4. Daemon's next tick (≤1s) re-reads `last_stdin.json` with fresh data
5. Following Claude Code render shows updated values
6. End-to-end propagation lag: 1-2s

## Verified live
- Inline path: injecting stdin with 7d=79 immediately renders `7d[79%]` and updates cache.
- Daemon path: injecting stdin with 7d=85 → first render still shows 79 (daemon's old snapshot) → wait 1.5s → next render shows 85.

## Tests
+2 cases (239 → 241):
- Regression: thin client must write stdin bytes to `last_stdin.json`
- Fallback path replays consumed stdin into `sys.stdin` for `core.main()`

## Release
This blocks v3.2.0 from being usable in fast mode. Suggest cutting v3.2.1 immediately after merge.
