### PR TITLE
fix: cache widget shows COUNTDOWN to expiry, not elapsed time (v3.2.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-statusbar",
   "description": "Lightweight Claude Code status-line monitor with switchable styles, themes, and slash commands. v3.2 adds daemon fast-mode (`cs --setup --fast`) for ~5× lower CPU at refreshInterval=1. Requires the `cs` CLI from PyPI (`pip install claude-statusbar` or `uv tool install claude-statusbar`).",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "author": {
     "name": "leeguooooo",
     "email": "leeguooooo@gmail.com"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Lightweight Claude Code status-line monitor. Shows your 5h / 7d rate-limit usage, reset timers, current model, context window, prompt-cache freshness, and (optionally) session cost — in a single compact line driven by Claude Code's `statusLine` hook.
 
 ```
-5h[   27%    ]⏰1h28m | 7d[   79%    ]⏰11h28m | Opus 4.7(350.0k/1.0M) | cache 0s
+5h[   27%    ]⏰1h28m | 7d[   79%    ]⏰11h28m | Opus 4.7(350.0k/1.0M) | cache 4m23s
 ```
 
 3 styles × 7 themes, configurable in one command. Auto-updates from PyPI. New in **v3.2**: a daemon mode that drops 1 Hz refresh CPU from ~6% to ~2% — same status line, ~5× cheaper.
@@ -35,7 +35,7 @@ Lightweight Claude Code status-line monitor. Shows your 5h / 7d rate-limit usage
 
 - **Daemon fast-mode** — `cs --setup --fast` swaps the statusLine command to `cs render` backed by a long-lived `cs daemon`. At `refreshInterval: 1` this cuts continuous CPU from ~6% to ~2%, render wall-clock from ~60ms to ~5ms. Crash-safe (auto-falls-back to inline render if the daemon dies; lazy-respawns).
 - **OS-managed daemon** — `cs daemon install` installs a launchd agent (macOS) or systemd user unit (Linux) so the daemon auto-starts on login and is restarted on crash by the OS.
-- **`cache 15s` segment** — opt-in via `cs config set show_cache_age true`. Shows time since Claude's last assistant turn, flips to `cache COLD` past Anthropic's 5-minute prompt-cache TTL. Configurable TTL via `cs config set cache_ttl_seconds 3600` for users on the 1-hour extended cache.
+- **`cache 4m23s` countdown** — opt-in via `cs config set show_cache_age true`. Counts down to Anthropic's prompt-cache expiry (default 5min TTL); flips through green → yellow (<1min) → red `cache COLD`. Configurable TTL via `cs config set cache_ttl_seconds 3600` for users on the 1-hour extended cache. The cache itself makes follow-up requests ~10× cheaper input-token cost — the widget tells you whether your next prompt will hit warm cache or pay full price.
 - **`cs doctor` 1Hz hint** — detects `refreshInterval ≤ 2s` with the inline command and recommends `cs --setup --fast`.
 - **Import-shaving on the inline path** — even users who don't opt into daemon mode get ~30% faster renders.
 
@@ -44,7 +44,7 @@ Existing users: nothing changes by default. Daemon mode is opt-in.
 ## What it shows
 
 ```
-5h[   27%    ]⏰1h28m | 7d[   79%    ]⏰11h28m | Opus 4.7(350.0k/1.0M) | cache 0s | $ 1.42
+5h[   27%    ]⏰1h28m | 7d[   79%    ]⏰11h28m | Opus 4.7(350.0k/1.0M) | cache 4m23s | $ 1.42
 ```
 
 | Segment | Meaning |
@@ -54,7 +54,7 @@ Existing users: nothing changes by default. Daemon mode is opt-in.
 | `7d[79%]` | 7-day rate-limit usage |
 | `⏰11h28m` | Time until the 7-day window resets |
 | `Opus 4.7(350.0k/1.0M)` | Model name + current context window usage |
-| `cache 0s` / `cache COLD` | Prompt-cache age — green warm, red cold (opt-in: `cs config set show_cache_age true`) |
+| `cache 4m23s` / `cache COLD` | Countdown to prompt-cache expiry (5min TTL by default). Green when comfortable, yellow under 1min, red on COLD. Cache hits cost ~10× less input tokens, so this tells you whether your next prompt is cheap. Opt-in: `cs config set show_cache_age true` |
 | `$ 1.42` | Session cost so far in USD (opt-in: `cs config set show_cost true`) |
 | `📚 EN:6.0↑ JA:5.0→` | IELTS band progress (requires [prompt-language-coach](https://github.com/leeguooooo/prompt-language-coach)) |
 
@@ -188,7 +188,7 @@ Persisted to `~/.claude/claude-statusbar.json`:
 | `auto_compact_width` | integer (e.g. `100`) | Force `hairline` when terminal narrower than this. `0` = disabled |
 | `show_weekly`, `show_language` | bool | Hide individual segments |
 | `show_cost` | bool, default `false` | Append a `$ X.XX` segment with the current session's cost (from Claude Code's stdin payload). Opt-in because the "session" boundary is what Claude Code reports — not necessarily what you intuitively call one |
-| `show_cache_age` | bool, default `false` | Append a `cache 15s` (green) / `cache COLD` (red) segment showing how long since Claude's last assistant turn. Anthropic's prompt cache TTL is 5 minutes — the segment flips to `COLD` past that. Useful to see at a glance whether your next request will hit the warm cache. **Requires `"refreshInterval": N` in your `~/.claude/settings.json` `statusLine` block** (e.g. `30`) — without it Claude Code only re-renders on activity, so the value freezes. Contributed by [@marcwimmer](https://github.com/marcwimmer) in [#9](https://github.com/leeguooooo/claude-code-usage-bar/pull/9). |
+| `show_cache_age` | bool, default `false` | Append a `cache 4m23s` countdown to Anthropic's prompt-cache expiry. Three-level color: green (>1min remaining), yellow (<1min), red `cache COLD` (expired). Cache hits cost ~10× less input tokens, so the widget answers "will my next prompt be cheap?". **Requires `"refreshInterval": N` in your `~/.claude/settings.json` `statusLine` block** (e.g. `30`, or `1` for live ticking — pair with [fast mode](#fast-mode--for-refreshinterval-1) at 1Hz). Original implementation contributed by [@marcwimmer](https://github.com/marcwimmer) in [#9](https://github.com/leeguooooo/claude-code-usage-bar/pull/9). |
 | `cache_ttl_seconds` | int, default `300` | TTL the `show_cache_age` segment uses to decide warm vs. `COLD`. Defaults to Anthropic's 5-minute prompt cache. Set to `3600` if you've enabled the [1-hour extended cache](https://docs.claude.com/en/docs/build-with-claude/prompt-caching) via `ENABLE_PROMPT_CACHING_1H`. |
 
 Set via `cs config set <key> <value>`. Wipe everything back to defaults with `cs config reset`.
@@ -317,7 +317,7 @@ cs --json-output
 
 ## Data source
 
-Rate-limit percentages come directly from **Anthropic's official API headers**, surfaced into the JSON payload Claude Code injects on stdin to every `statusLine` command. Context-window usage comes from the same payload. The optional `cache 15s` segment is computed locally by tail-reading the active transcript JSONL — Anthropic's prompt cache TTL is 5 minutes by default ([Mar 2026 change](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)) or 1 hour with `ENABLE_PROMPT_CACHING_1H`.
+Rate-limit percentages come directly from **Anthropic's official API headers**, surfaced into the JSON payload Claude Code injects on stdin to every `statusLine` command. Context-window usage comes from the same payload. The optional `cache 4m23s` countdown is computed locally by tail-reading the active transcript JSONL — Anthropic's prompt cache TTL is 5 minutes by default ([Mar 2026 change](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)) or 1 hour with `ENABLE_PROMPT_CACHING_1H`.
 
 Requires Claude Code `v2.1.80+`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-statusbar"
-version = "3.2.1"
+version = "3.2.2"
 authors = [
     {name = "leeguooooo", email = "leeguooooo@gmail.com"}
 ]

--- a/src/claude_statusbar/core.py
+++ b/src/claude_statusbar/core.py
@@ -952,16 +952,24 @@ def _last_assistant_age(transcript_path: str) -> Optional[float]:
 
 
 def get_cache_age_text(ttl_seconds: int = 300) -> str:
-    """Return cache age: 'Xm Ys' if <ttl_seconds, else 'COLD'.
+    """Return cache state as a COUNTDOWN to expiry.
+
+    Display semantics:
+      - "Xm YYs" / "Ys" — time remaining before Anthropic's prompt cache
+        expires. Decreasing number = increasing urgency, matching the
+        `⏰2h14m` reset countdowns elsewhere on the line.
+      - "COLD"          — cache has expired (or transcript has no
+        assistant entry). Next API call pays full input-token price.
+      - ""              — no signal at all (no last_stdin.json or
+        no transcript_path); segment hidden.
 
     `ttl_seconds` defaults to Anthropic's 5min prompt cache TTL but is
     user-configurable via `cs config set cache_ttl_seconds 3600` for users
-    who've enabled the 1-hour cache option.
+    who've enabled the 1-hour extended cache (ENABLE_PROMPT_CACHING_1H).
 
-    Returns "" (segment hidden) only when we have no signal at all — no
-    last_stdin.json or no transcript_path in it. If the transcript exists but
-    has no assistant entry yet, the cache is by definition cold, so render
-    COLD instead of inventing a freshness from the cache file's mtime.
+    Why countdown not elapsed: the widget exists to answer "should I send
+    my next prompt before the cache dies?". A countdown answers directly;
+    elapsed forces the user to mentally subtract.
     """
     cache_file = Path.home() / ".cache" / "claude-statusbar" / "last_stdin.json"
 
@@ -977,16 +985,20 @@ def get_cache_age_text(ttl_seconds: int = 300) -> str:
     if age_s is None:
         return "COLD"
 
-    if age_s > ttl_seconds:
-        return "COLD"
-    # Clock-skew clamp: if the transcript timestamp is in the future (NTP
-    # correction or sandbox time-warp), `age_s` goes negative and produces
-    # nonsense like "-1m" / "-30s". Floor to 0 so the segment renders as
-    # "cache 0s" until the wall clock catches up.
+    # Clock-skew clamp: future transcript timestamp (NTP correction or
+    # sandbox time-warp) → treat as just-now (full TTL remaining).
     if age_s < 0:
         age_s = 0
-    mins = int(age_s) // 60
-    secs = int(age_s) % 60
+
+    remaining = ttl_seconds - age_s
+    if remaining <= 0:
+        return "COLD"
+
+    # Round UP so a render at t=0.4s into a 5min TTL still shows 5m00s,
+    # not 4m59s — feels less surprising for the user who just hit enter.
+    remaining_int = int(remaining) if remaining == int(remaining) else int(remaining) + 1
+    mins = remaining_int // 60
+    secs = remaining_int % 60
     if mins > 0:
         return f"{mins}m{secs:02d}s"
     return f"{secs}s"

--- a/src/claude_statusbar/styles.py
+++ b/src/claude_statusbar/styles.py
@@ -37,6 +37,23 @@ def _severity_color(theme: Theme, pct: Optional[float],
     return theme.s_ok
 
 
+def _cache_severity(theme: Theme, cache_text: str) -> tuple:
+    """Map a countdown cache string to a severity color.
+
+    "COLD"            → s_hot   (red, expired)
+    "<1m" remaining   → s_warn  (yellow, ~1min left)
+    otherwise         → s_ok    (green, comfortable)
+
+    The "<1m" detection works because the countdown formatter only emits
+    "Xm YYs" when minutes > 0; sub-minute remainders render as "Ys".
+    """
+    if cache_text == "COLD":
+        return theme.s_hot
+    if "m" not in cache_text:
+        return theme.s_warn
+    return theme.s_ok
+
+
 # ---------------------------------------------------------------------------
 # Style: capsule
 # ---------------------------------------------------------------------------
@@ -94,8 +111,7 @@ def render_capsule(
         parts.append(pill(theme.pill_lang, f"📚 {lang_body}"))
 
     if cache_age_text:
-        is_cold = cache_age_text == "COLD"
-        bg = theme.s_hot if is_cold else theme.s_ok
+        bg = _cache_severity(theme, cache_age_text)
         parts.append(pill(bg, f"cache {cache_age_text}"))
 
     line = spacer.join(parts)
@@ -163,7 +179,7 @@ def render_hairline(
         parts.append(f"{MUTE}{lang_body}{RESET}")
 
     if cache_age_text:
-        col = _fg(theme.s_hot) if cache_age_text == "COLD" else _fg(theme.s_ok)
+        col = _fg(_cache_severity(theme, cache_age_text))
         parts.append(f"{col}cache {cache_age_text}{RESET}")
 
     if bypass:
@@ -202,8 +218,16 @@ def render_classic(
         cost_text=cost_text,
     )
     if cache_age_text:
-        from .progress import GREEN, RED
-        col = RED if cache_age_text == "COLD" else GREEN
+        from .progress import GREEN, YELLOW, RED
+        # Three-level severity matching the countdown: COLD red, <1m
+        # remaining yellow, otherwise green. Same logic as the capsule /
+        # hairline _cache_severity helper, just on RGB ANSI codes.
+        if cache_age_text == "COLD":
+            col = RED
+        elif "m" not in cache_age_text:
+            col = YELLOW
+        else:
+            col = GREEN
         # Reset before our segment so it doesn't inherit the trailing color
         # from format_status_line's last colorized chunk.
         result += f"{RESET} | {colorize(f'cache {cache_age_text}', col, use_color)}"

--- a/tests/test_cache_age.py
+++ b/tests/test_cache_age.py
@@ -180,13 +180,15 @@ def test_cache_text_cold_when_no_assistant_yet(tmp_path: Path, monkeypatch):
     assert core.get_cache_age_text() == "COLD"
 
 
-def test_cache_text_warm_minutes_format(tmp_path: Path, monkeypatch):
+def test_cache_text_warm_countdown_format(tmp_path: Path, monkeypatch):
+    """130s elapsed of a 300s TTL → 170s remaining → "2m50s"."""
     transcript = tmp_path / "t.jsonl"
     ts = datetime.now(timezone.utc) - timedelta(seconds=130)
     _write_jsonl(transcript, [{"type": "assistant", "timestamp": ts.isoformat()}])
     _install_fake_cache(monkeypatch, tmp_path, {"transcript_path": str(transcript)})
     out = core.get_cache_age_text()
-    assert out.startswith("2m")
+    # 300 - 130 = 170s remaining = 2m50s (small jitter possible from test timing)
+    assert out.startswith("2m"), f"expected 2m... countdown, got {out!r}"
     assert out.endswith("s")
 
 
@@ -203,24 +205,43 @@ def test_cache_text_empty_when_no_transcript_path(tmp_path: Path, monkeypatch):
 
 def test_cache_text_clamps_future_timestamp(tmp_path: Path, monkeypatch):
     """Clock-skew defense: a transcript timestamp in the future must NOT
-    produce nonsense output like 'cache -1m' or '-30s'. Floor to 0."""
+    overflow remaining (would show 7m+ for a 5m TTL). Treat as just-now,
+    so countdown shows the full TTL."""
     transcript = tmp_path / "t.jsonl"
     future = datetime.now(timezone.utc) + timedelta(seconds=120)
     _write_jsonl(transcript, [{"type": "assistant", "timestamp": future.isoformat()}])
     _install_fake_cache(monkeypatch, tmp_path, {"transcript_path": str(transcript)})
     out = core.get_cache_age_text()
-    assert out == "0s", f"future timestamp must clamp to '0s', got {out!r}"
+    # Future timestamp clamped to 0 elapsed → 5m TTL fully remaining.
+    assert out.startswith("5m"), f"expected 5m... full countdown, got {out!r}"
 
 
 def test_cache_text_respects_custom_ttl(tmp_path: Path, monkeypatch):
-    """Users on the 1h Anthropic cache pass ttl_seconds=3600; entries between
-    300s and 3600s should still report warm, not COLD."""
+    """Users on the 1h Anthropic cache pass ttl_seconds=3600; entries 600s
+    in should report 50min remaining, not COLD."""
     transcript = tmp_path / "t.jsonl"
     ts = datetime.now(timezone.utc) - timedelta(seconds=600)  # 10 min old
     _write_jsonl(transcript, [{"type": "assistant", "timestamp": ts.isoformat()}])
     _install_fake_cache(monkeypatch, tmp_path, {"transcript_path": str(transcript)})
-    # Default 300s TTL → COLD
+    # Default 300s TTL → 600s elapsed → already expired → COLD
     assert core.get_cache_age_text(300) == "COLD"
-    # 1h TTL → still warm, formatted as 10m
+    # 1h TTL → 600s elapsed → 3000s remaining → 50m
     out = core.get_cache_age_text(3600)
-    assert out.startswith("10m"), f"expected 10m..., got {out!r}"
+    assert out.startswith("50m") or out.startswith("49m"), \
+        f"expected ~50m countdown, got {out!r}"
+
+
+def test_cache_text_emits_sub_minute_for_warning_state(tmp_path: Path, monkeypatch):
+    """The styles layer keys yellow vs green off whether 'm' is in the text:
+    sub-minute remaining must NOT include an 'm' so it triggers warning color."""
+    transcript = tmp_path / "t.jsonl"
+    # 280s elapsed of 300s TTL → 20s remaining
+    ts = datetime.now(timezone.utc) - timedelta(seconds=280)
+    _write_jsonl(transcript, [{"type": "assistant", "timestamp": ts.isoformat()}])
+    _install_fake_cache(monkeypatch, tmp_path, {"transcript_path": str(transcript)})
+    out = core.get_cache_age_text()
+    assert out.endswith("s")
+    assert "m" not in out, (
+        f"sub-minute remaining must omit 'm' so styles layer can detect "
+        f"warning state via the missing-m check; got {out!r}"
+    )


### PR DESCRIPTION
## TL;DR
\`cache 30s\` (elapsed) → \`cache 4m30s\` (remaining). Three-level color: green / yellow under 1min / red on COLD.

## Why
The cache widget answers one question: **should I send my next prompt before the cache dies?**

A countdown answers it directly. Elapsed forces the user to remember the TTL (5min default) and subtract. It also was inconsistent with the rest of the line — \`5h ⏰2h14m\` and \`7d ⏰12h35m\` are both countdowns; only the cache segment counted up.

Falling-number-as-urgency is universal UX (rocket countdowns, expiration timers, download ETAs).

We kept elapsed initially because it was the shape of the original PR #9 from @marcwimmer; we kept it through Phase D without rethinking the semantics.

## Numbers shipped on the line

| state              | text         | color  |
|--------------------|--------------|--------|
| > 1min remaining   | \`cache 4m30s\`, \`cache 1m05s\` | green  (s_ok) |
| <= 1min remaining  | \`cache 45s\`, \`cache 5s\`     | yellow (s_warn) |
| expired            | \`cache COLD\`                  | red    (s_hot) |

The styles layer detects yellow vs green by checking whether \`m\` appears in the text — sub-minute formatter omits it (\`45s\`, not \`0m45s\`). That contract is now pinned by a test.

## Why this matters in money terms
Cache hits cost ~10× less input tokens. A 200k-token Claude Code conversation:
- Cache HIT next prompt: ~\$0.30 input
- Cache COLD next prompt: ~\$3.00 input

Knowing \"I have 30 seconds before that 10× cost kicks in\" is actionable. \"30 seconds elapsed\" is not.

## Tests
- Updated 3 existing assertions to new countdown semantics
- New: \`test_cache_text_emits_sub_minute_for_warning_state\` pins the \"no m in text\" contract
- 242 tests passing (was 241)

## Verified live (all 3 styles, all 3 states)
- classic / capsule / hairline render the countdown correctly
- 4m59s green → 30s yellow → COLD red transitions all smooth
- README updated: hero example, segments table, configuration row, data-source explanation