### PR TITLE
feat: refreshInterval=1 default + subscriber-correct README (v3.2.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-statusbar",
   "description": "Lightweight Claude Code status-line monitor with switchable styles, themes, and slash commands. v3.2 adds daemon fast-mode (`cs --setup --fast`) for ~5× lower CPU at refreshInterval=1. Requires the `cs` CLI from PyPI (`pip install claude-statusbar` or `uv tool install claude-statusbar`).",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "author": {
     "name": "leeguooooo",
     "email": "leeguooooo@gmail.com"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Lightweight Claude Code status-line monitor. Shows your 5h / 7d rate-limit usage
 
 - **Daemon fast-mode** — `cs --setup --fast` swaps the statusLine command to `cs render` backed by a long-lived `cs daemon`. At `refreshInterval: 1` this cuts continuous CPU from ~6% to ~2%, render wall-clock from ~60ms to ~5ms. Crash-safe (auto-falls-back to inline render if the daemon dies; lazy-respawns).
 - **OS-managed daemon** — `cs daemon install` installs a launchd agent (macOS) or systemd user unit (Linux) so the daemon auto-starts on login and is restarted on crash by the OS.
-- **`cache 4m23s` countdown** — opt-in via `cs config set show_cache_age true`. Counts down to Anthropic's prompt-cache expiry (default 5min TTL); flips through green → yellow (<1min) → red `cache COLD`. Configurable TTL via `cs config set cache_ttl_seconds 3600` for users on the 1-hour extended cache. The cache itself makes follow-up requests ~10× cheaper input-token cost — the widget tells you whether your next prompt will hit warm cache or pay full price.
+- **`cache 4m23s` countdown** — opt-in via `cs config set show_cache_age true`. Counts down to Anthropic's prompt-cache expiry (default 5min TTL); flips through green → yellow (<1min) → red `cache COLD`. Configurable TTL via `cs config set cache_ttl_seconds 3600` for users on the 1-hour extended cache. **For Pro/Max subscribers**, cache hits consume ~10× less of your 5h / 7d rate-limit quota — letting it go COLD costs you ~10× more quota on the next prompt. The widget tells you whether to send now or wrap up first.
 - **`cs doctor` 1Hz hint** — detects `refreshInterval ≤ 2s` with the inline command and recommends `cs --setup --fast`.
 - **Import-shaving on the inline path** — even users who don't opt into daemon mode get ~30% faster renders.
 
@@ -54,8 +54,8 @@ Existing users: nothing changes by default. Daemon mode is opt-in.
 | `7d[79%]` | 7-day rate-limit usage |
 | `⏰11h28m` | Time until the 7-day window resets |
 | `Opus 4.7(350.0k/1.0M)` | Model name + current context window usage |
-| `cache 4m23s` / `cache COLD` | Countdown to prompt-cache expiry (5min TTL by default). Green when comfortable, yellow under 1min, red on COLD. Cache hits cost ~10× less input tokens, so this tells you whether your next prompt is cheap. Opt-in: `cs config set show_cache_age true` |
-| `$ 1.42` | Session cost so far in USD (opt-in: `cs config set show_cost true`) |
+| `cache 4m23s` / `cache COLD` | Countdown to prompt-cache expiry (5min TTL by default). Green when comfortable, yellow under 1min, red on COLD. Cache hits consume ~10× less rate-limit quota — for subscribers this means COLD prompts eat your 5h / 7d windows ~10× faster. Opt-in: `cs config set show_cache_age true` |
+| `$ 1.42` | Session cost in USD as Claude Code reports it. For Pro/Max subscribers this is the **API-equivalent value** of your usage (i.e. what it would cost on the API), not money owed. Useful as an ROI signal. Opt-in: `cs config set show_cost true` |
 | `📚 EN:6.0↑ JA:5.0→` | IELTS band progress (requires [prompt-language-coach](https://github.com/leeguooooo/prompt-language-coach)) |
 
 Colors default to green / yellow / red at `30%` and `70%` — both thresholds configurable.
@@ -85,12 +85,12 @@ Then add to `~/.claude/settings.json`:
   "statusLine": {
     "type": "command",
     "command": "cs",
-    "refreshInterval": 30
+    "refreshInterval": 1
   }
 }
 ```
 
-`refreshInterval` is in seconds. Set it to `1` if you enable [`show_cache_age`](#configuration-file) and want the cache timer to tick visibly — and pair that with [fast mode](#fast-mode--for-refreshinterval-1).
+`cs --setup` writes `refreshInterval: 1` by default so the cache-age countdown ticks visibly. At 1Hz, the inline `cs` command runs ~30ms per render (~3% CPU continuously); if that's a concern, run `cs --setup --fast` instead — daemon mode brings it under 1%. To go quieter, set `refreshInterval` to a higher value (`30`, `60`) — `cs --setup` will preserve any explicit value you've already chosen.
 
 ## Styles & themes
 
@@ -187,8 +187,8 @@ Persisted to `~/.claude/claude-statusbar.json`:
 | `density` | `compact` / `regular` / `cozy` | Padding around segments (capsule + hairline only) |
 | `auto_compact_width` | integer (e.g. `100`) | Force `hairline` when terminal narrower than this. `0` = disabled |
 | `show_weekly`, `show_language` | bool | Hide individual segments |
-| `show_cost` | bool, default `false` | Append a `$ X.XX` segment with the current session's cost (from Claude Code's stdin payload). Opt-in because the "session" boundary is what Claude Code reports — not necessarily what you intuitively call one |
-| `show_cache_age` | bool, default `false` | Append a `cache 4m23s` countdown to Anthropic's prompt-cache expiry. Three-level color: green (>1min remaining), yellow (<1min), red `cache COLD` (expired). Cache hits cost ~10× less input tokens, so the widget answers "will my next prompt be cheap?". **Requires `"refreshInterval": N` in your `~/.claude/settings.json` `statusLine` block** (e.g. `30`, or `1` for live ticking — pair with [fast mode](#fast-mode--for-refreshinterval-1) at 1Hz). Original implementation contributed by [@marcwimmer](https://github.com/marcwimmer) in [#9](https://github.com/leeguooooo/claude-code-usage-bar/pull/9). |
+| `show_cost` | bool, default `false` | Append `$ X.XX` — the current session's cost as Claude Code reports it. For Pro/Max subscribers this is the **API-equivalent value** of your usage (what it would cost on the API), not money owed; many subscribers use it as a "subscription ROI" gauge. Opt-in because the "session" boundary is what Claude Code reports — not necessarily what you intuitively call one. |
+| `show_cache_age` | bool, default `false` | Append a `cache 4m23s` countdown to Anthropic's prompt-cache expiry. Three-level color: green (>1min remaining), yellow (<1min), red `cache COLD` (expired). Cache hits consume ~10× less rate-limit quota — for Pro/Max subscribers, letting it go COLD eats your 5h / 7d windows ~10× faster. `cs --setup` writes `refreshInterval: 1` by default so this segment ticks visibly. Original implementation contributed by [@marcwimmer](https://github.com/marcwimmer) in [#9](https://github.com/leeguooooo/claude-code-usage-bar/pull/9). |
 | `cache_ttl_seconds` | int, default `300` | TTL the `show_cache_age` segment uses to decide warm vs. `COLD`. Defaults to Anthropic's 5-minute prompt cache. Set to `3600` if you've enabled the [1-hour extended cache](https://docs.claude.com/en/docs/build-with-claude/prompt-caching) via `ENABLE_PROMPT_CACHING_1H`. |
 
 Set via `cs config set <key> <value>`. Wipe everything back to defaults with `cs config reset`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-statusbar"
-version = "3.2.2"
+version = "3.2.3"
 authors = [
     {name = "leeguooooo", email = "leeguooooo@gmail.com"}
 ]

--- a/src/claude_statusbar/setup.py
+++ b/src/claude_statusbar/setup.py
@@ -60,17 +60,32 @@ def _resolve_cs_command() -> str:
     return "cs"
 
 
-def _statusline_config(fast: bool = False) -> dict:
+# Default refresh interval. 1 second so the cache-age countdown actually
+# ticks visibly out of the box. At inline cost (~30ms/render) that's ~3%
+# CPU; users who care about that overhead should pair with `--fast`
+# (daemon mode brings it under 1%).
+DEFAULT_REFRESH_INTERVAL = 1
+
+
+def _statusline_config(fast: bool = False, refresh_interval: int = DEFAULT_REFRESH_INTERVAL) -> dict:
     """Build the statusLine entry we want to write.
 
     `fast=True` emits ``cs render`` (Phase B daemon thin client). The bare
     ``cs`` form keeps the legacy inline path so existing users aren't
     affected by this change.
+
+    `refresh_interval` is written into settings.json so the cache-age
+    countdown actually animates. Without it, Claude Code only re-renders
+    on activity (turn complete, tool use), and time-based segments freeze.
     """
     cmd = _resolve_cs_command()
     if fast:
         cmd = f"{cmd} render"
-    return {"type": "command", "command": cmd}
+    return {
+        "type": "command",
+        "command": cmd,
+        "refreshInterval": refresh_interval,
+    }
 
 
 def _is_our_statusline(entry: object) -> bool:
@@ -161,12 +176,20 @@ def ensure_statusline_configured(fast: bool = False) -> Tuple[bool, str]:
             f"manually if you want claude-statusbar."
         )
 
-    # Ours already. Compute desired command preserving fast mode if the user
-    # currently uses it (so the daily auto-repair never downgrades them).
+    # Ours already. Compute desired command preserving (a) fast mode if the
+    # user currently uses it (so the daily auto-repair never downgrades them)
+    # and (b) any explicit refreshInterval the user already set, so we don't
+    # silently bump someone's 60s cadence to our 1s default.
     effective_fast = fast or _existing_uses_render(existing)
-    desired = _statusline_config(fast=effective_fast)
+    existing_refresh = existing.get("refreshInterval")
+    if isinstance(existing_refresh, (int, float)) and existing_refresh > 0:
+        effective_refresh = int(existing_refresh)
+    else:
+        effective_refresh = DEFAULT_REFRESH_INTERVAL
+    desired = _statusline_config(fast=effective_fast, refresh_interval=effective_refresh)
 
-    if existing.get("command") != desired["command"]:
+    if (existing.get("command") != desired["command"]
+            or existing.get("refreshInterval") != desired["refreshInterval"]):
         settings["statusLine"] = desired
         if _write_settings(settings):
             return True, (

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -236,6 +236,54 @@ def test_statusline_config_default_no_render():
     assert not cfg["command"].endswith(" render")
 
 
+def test_statusline_config_includes_default_refresh_interval():
+    """v3.2.3+: default config writes refreshInterval=1 so the cache-age
+    countdown actually animates out of the box."""
+    from claude_statusbar.setup import DEFAULT_REFRESH_INTERVAL
+    cfg = _statusline_config()
+    assert cfg["refreshInterval"] == DEFAULT_REFRESH_INTERVAL == 1
+
+
+def test_statusline_config_honors_explicit_refresh_interval():
+    cfg = _statusline_config(refresh_interval=30)
+    assert cfg["refreshInterval"] == 30
+
+
+def test_ensure_statusline_preserves_explicit_refresh_interval(tmp_path: Path, monkeypatch):
+    """If the user manually set refreshInterval=60, the daily auto-repair
+    must NOT silently bump it to our 1s default."""
+    from claude_statusbar import setup as setup_mod
+    settings = tmp_path / "settings.json"
+    monkeypatch.setattr(setup_mod, "SETTINGS_PATH", settings)
+    settings.write_text(json.dumps({
+        "statusLine": {
+            "type": "command",
+            "command": "/abs/path/cs",
+            "refreshInterval": 60,
+        },
+    }), encoding="utf-8")
+
+    setup_mod.ensure_statusline_configured(fast=False)
+
+    after = json.loads(settings.read_text(encoding="utf-8"))
+    assert after["statusLine"]["refreshInterval"] == 60, (
+        f"daily auto-repair must preserve explicit refreshInterval; got "
+        f"{after['statusLine'].get('refreshInterval')!r}"
+    )
+
+
+def test_ensure_statusline_writes_default_refresh_interval_for_new_install(tmp_path: Path, monkeypatch):
+    """Fresh install (no settings.json yet): default refreshInterval=1."""
+    from claude_statusbar import setup as setup_mod
+    settings = tmp_path / "settings.json"
+    monkeypatch.setattr(setup_mod, "SETTINGS_PATH", settings)
+
+    setup_mod.ensure_statusline_configured(fast=False)
+
+    after = json.loads(settings.read_text(encoding="utf-8"))
+    assert after["statusLine"]["refreshInterval"] == 1
+
+
 # ---------------------------------------------------------------------------
 # Codex review fixes
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two related changes:

## 1. `cs --setup` writes `refreshInterval: 1` by default
Previously, users had to discover `refreshInterval` themselves to see the cache-age countdown tick. Most never did → widget appeared frozen.

Migration is safe — ensures _existing_ users' explicit choices survive:
- Fresh install (no settings.json): writes `refreshInterval: 1`
- User had no refreshInterval but our `cs` command: writes `1`
- User had explicit `refreshInterval: 60`: **preserved** (daily auto-repair won't downgrade)

At 1Hz the inline `cs` runs ~30ms/render = ~3% CPU. Users who care about that pair with `cs --setup --fast` (daemon mode → <1% CPU). The doctor 1Hz hint already nudges inline users in that direction.

## 2. README correction — subscriber framing
The previous README explained the cache widget in $/MTok terms, but ~95% of Claude Code users are Pro/Max subscribers paying a flat monthly fee. They don't pay per token. Reframed throughout:

- ❌ "Cache hits cost ~10× less input tokens"
- ✅ "Cache hits consume ~10× less rate-limit quota — for subscribers, COLD prompts eat your 5h / 7d windows ~10× faster"

`show_cost` segment now documented as "API-equivalent value" (a subscription-ROI gauge) rather than "money owed".

## Tests
+4 cases (242 → 246):
- `_statusline_config` defaults to refreshInterval=1
- `_statusline_config` honors explicit refresh_interval arg
- `ensure_statusline_configured` preserves explicit refreshInterval=60 through daily auto-repair (regression guard, same pattern as Phase D fast-mode preservation)
- `ensure_statusline_configured` writes refreshInterval=1 on fresh install

## Verified live
- Fresh install: settings.json gets refreshInterval=1
- After auto-repair on user's manual 60s setting: still 60s
