### PR TITLE
fix(daemon): per-session buckets — multi-window safe (v3.3.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-statusbar",
   "description": "Lightweight Claude Code status-line monitor with switchable styles, themes, and slash commands. v3.2 adds daemon fast-mode (`cs --setup --fast`) for ~5× lower CPU at refreshInterval=1. Requires the `cs` CLI from PyPI (`pip install claude-statusbar` or `uv tool install claude-statusbar`).",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "author": {
     "name": "leeguooooo",
     "email": "leeguooooo@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-statusbar"
-version = "3.2.3"
+version = "3.3.0"
 authors = [
     {name = "leeguooooo", email = "leeguooooo@gmail.com"}
 ]

--- a/src/claude_statusbar/daemon.py
+++ b/src/claude_statusbar/daemon.py
@@ -57,9 +57,50 @@ def _cache_dir() -> Path:
 
 
 def pid_path() -> Path: return _cache_dir() / "daemon.pid"
+def log_path() -> Path: return _cache_dir() / "daemon.log"
+
+
+# Per-session state (v3.3.0+) — multi-window safe.
+# Each Claude Code window has a unique session_id; we render each one to its
+# own bucket so two windows never overwrite each other's rendered.ansi.
+def sessions_root() -> Path:
+    d = _cache_dir() / "sessions"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def session_dir(session_id: str) -> Path:
+    """Per-session state directory. session_id comes from Claude Code's
+    stdin payload — a UUID-like string, safe to use as a path segment
+    after sanitisation."""
+    safe = "".join(c for c in (session_id or "default") if c.isalnum() or c in "-_")[:64]
+    if not safe:
+        safe = "default"
+    d = sessions_root() / safe
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def session_stdin_path(session_id: str) -> Path:
+    return session_dir(session_id) / "last_stdin.json"
+
+
+def session_rendered_path(session_id: str) -> Path:
+    return session_dir(session_id) / "rendered.ansi"
+
+
+def session_meta_path(session_id: str) -> Path:
+    return session_dir(session_id) / "rendered.meta.json"
+
+
+# Legacy: kept for inline-mode compatibility (cs without `render` subcmd
+# still writes here via parse_stdin_data). Not used by the daemon's
+# per-session render loop.
 def rendered_path() -> Path: return _cache_dir() / "rendered.ansi"
 def meta_path() -> Path: return _cache_dir() / "rendered.meta.json"
-def log_path() -> Path: return _cache_dir() / "daemon.log"
+
+
+SESSION_GC_AFTER_S = 24 * 60 * 60  # drop session dirs idle > 1 day
 
 
 # ---------------------------------------------------------------------------
@@ -179,20 +220,9 @@ def _process_is_our_daemon(pid: int) -> bool:
 # ---------------------------------------------------------------------------
 # Render — capture core.main()'s stdout into a string
 # ---------------------------------------------------------------------------
-def _render_once() -> Optional[str]:
-    """Drive core.main() through redirect_stdout to grab the rendered ANSI.
-
-    The daemon pretends to be Claude Code: it replays the cached stdin
-    payload (last_stdin.json) into sys.stdin, calls core.main with side
-    effects suppressed, and captures whatever is printed.
-    """
-    cache_file = _cache_dir() / "last_stdin.json"
-    try:
-        payload = cache_file.read_text(encoding="utf-8")
-    except OSError:
-        # No cached stdin yet — nothing to render. Daemon will retry next tick.
-        return None
-
+def _render_payload(payload: str) -> Optional[str]:
+    """Run core.main() with the given JSON payload as stdin and capture the
+    rendered ANSI string. Used by the per-session render loop below."""
     buf = io.StringIO()
     saved_stdin = sys.stdin
     sys.stdin = io.StringIO(payload)
@@ -205,24 +235,90 @@ def _render_once() -> Optional[str]:
         return None
     finally:
         sys.stdin = saved_stdin
-
     out = buf.getvalue().rstrip("\n")
     return out or None
 
 
-# ---------------------------------------------------------------------------
-# Atomic publish
-# ---------------------------------------------------------------------------
-def _publish(rendered: str) -> None:
-    """Write rendered.ansi + rendered.meta.json. Both atomic."""
+def _render_session(sid: str) -> bool:
+    """Render one session's status line and atomically publish it.
+
+    Returns True on success. False on any error (silent — daemon retries
+    next tick; thin client falls back to inline if meta goes stale).
+    """
+    stdin_file = session_stdin_path(sid)
+    try:
+        payload = stdin_file.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    rendered = _render_payload(payload)
+    if rendered is None:
+        return False
     now = time.time()
-    atomic_write_text(rendered_path(), rendered + "\n")
-    meta = {
+    atomic_write_text(session_rendered_path(sid), rendered + "\n")
+    atomic_write_text(session_meta_path(sid), json.dumps({
         "generated_at": now,
         "pid": os.getpid(),
         "stale_after_seconds": META_STALE_AFTER,
-    }
-    atomic_write_text(meta_path(), json.dumps(meta) + "\n")
+        "session_id": sid,
+    }) + "\n")
+    return True
+
+
+def _active_sessions() -> list[str]:
+    """List session_ids with a recent last_stdin.json. Sessions older than
+    SESSION_GC_AFTER_S are skipped (and pruned by _gc_old_sessions)."""
+    out = []
+    cutoff = time.time() - SESSION_GC_AFTER_S
+    try:
+        for d in sessions_root().iterdir():
+            if not d.is_dir():
+                continue
+            stdin = d / "last_stdin.json"
+            try:
+                if stdin.stat().st_mtime >= cutoff:
+                    out.append(d.name)
+            except OSError:
+                continue
+    except OSError:
+        pass
+    return out
+
+
+def _gc_old_sessions() -> None:
+    """Drop session dirs that haven't been touched for SESSION_GC_AFTER_S.
+
+    Called once per daemon-tick batch; cheap O(n) directory scan.
+    """
+    cutoff = time.time() - SESSION_GC_AFTER_S
+    try:
+        for d in sessions_root().iterdir():
+            if not d.is_dir():
+                continue
+            try:
+                stdin = d / "last_stdin.json"
+                if stdin.exists() and stdin.stat().st_mtime >= cutoff:
+                    continue
+                # Stale — remove the whole directory.
+                for f in d.iterdir():
+                    try:
+                        f.unlink()
+                    except OSError:
+                        pass
+                d.rmdir()
+                _log(f"gc'd stale session dir {d.name}")
+            except OSError:
+                continue
+    except OSError:
+        pass
+
+
+def _render_all_sessions() -> int:
+    """Render every active session. Returns the count rendered."""
+    n = 0
+    for sid in _active_sessions():
+        if _render_session(sid):
+            n += 1
+    return n
 
 
 # ---------------------------------------------------------------------------
@@ -264,12 +360,15 @@ def run_forever(render_interval: float = DEFAULT_RENDER_INTERVAL) -> int:
 
     _log(f"daemon started pid={os.getpid()} interval={render_interval}s")
 
+    last_gc = 0.0
+    GC_INTERVAL_S = 60 * 30  # garbage-collect stale session dirs every 30 min
     try:
         while _running:
             t0 = time.time()
-            rendered = _render_once()
-            if rendered is not None:
-                _publish(rendered)
+            _render_all_sessions()
+            if t0 - last_gc > GC_INTERVAL_S:
+                _gc_old_sessions()
+                last_gc = t0
             elapsed = time.time() - t0
             sleep_for = max(0.0, render_interval - elapsed)
             # Sleep in small chunks so signals are responsive.
@@ -286,8 +385,7 @@ def run_forever(render_interval: float = DEFAULT_RENDER_INTERVAL) -> int:
 # Subcommand handlers (called from cli.py)
 # ---------------------------------------------------------------------------
 def cmd_status() -> int:
-    """`cs daemon status` — report whether daemon is alive and rendered.ansi
-    freshness."""
+    """`cs daemon status` — daemon liveness + per-session rendered freshness."""
     pid = read_pidfile()
     if pid is None:
         print("daemon: not running (no pidfile)")
@@ -299,17 +397,26 @@ def cmd_status() -> int:
     print(f"daemon: pid {pid} {'alive' if alive else 'STALE pidfile (process gone)'}")
     if not alive:
         return 1
-    try:
-        meta = json.loads(meta_path().read_text(encoding="utf-8"))
-        age = time.time() - float(meta.get("generated_at", 0))
-        print(f"rendered.ansi: {age:.1f}s old (stale_after={meta.get('stale_after_seconds')}s)")
-        if age > META_STALE_AFTER:
-            print("WARNING: rendered output is stale — daemon may be wedged")
-            return 2
-    except (OSError, ValueError, json.JSONDecodeError) as e:
-        print(f"rendered.meta.json unreadable: {e}")
-        return 2
-    return 0
+
+    sids = _active_sessions()
+    if not sids:
+        print("sessions: none yet (daemon hasn't seen any cs render calls)")
+        return 0
+    print(f"sessions: {len(sids)} active")
+    bad = 0
+    for sid in sids:
+        try:
+            meta = json.loads(session_meta_path(sid).read_text(encoding="utf-8"))
+            age = time.time() - float(meta.get("generated_at", 0))
+            stale = age > META_STALE_AFTER
+            tag = " STALE" if stale else ""
+            print(f"  {sid[:8]}…  {age:.1f}s old{tag}")
+            if stale:
+                bad += 1
+        except (OSError, ValueError, json.JSONDecodeError) as e:
+            print(f"  {sid[:8]}…  meta unreadable: {e}")
+            bad += 1
+    return 0 if bad == 0 else 2
 
 
 def cmd_stop() -> int:

--- a/src/claude_statusbar/doctor.py
+++ b/src/claude_statusbar/doctor.py
@@ -130,23 +130,33 @@ def run() -> int:
         _line("last_stdin cache",
               _dim("not yet — Claude Code hasn't pushed any payload"))
 
-    # --- daemon (Phase B) ---
+    # --- daemon (Phase B+) ---
     try:
         from . import daemon as _d
         pid = _d.read_pidfile()
         if pid is None:
             _line("daemon", _dim("not running (statusLine in inline mode — fine, but slower)"))
         elif _d.is_alive(pid):
-            try:
-                meta = json.loads(_d.meta_path().read_text(encoding="utf-8"))
-                age = _dt.datetime.now().timestamp() - float(meta.get("generated_at", 0))
-                stale = float(meta.get("stale_after_seconds", 5.0))
-                if age <= stale:
-                    _line("daemon", f"pid {pid} alive  rendered.ansi {age:.1f}s old", ok=True)
+            sids = _d._active_sessions()
+            if not sids:
+                _line("daemon", f"pid {pid} alive  (no active sessions yet)", ok=True)
+            else:
+                # Summarise across all per-session buckets (v3.3.0+).
+                ages = []
+                stale_count = 0
+                for sid in sids:
+                    try:
+                        meta = json.loads(_d.session_meta_path(sid).read_text(encoding="utf-8"))
+                        age = _dt.datetime.now().timestamp() - float(meta.get("generated_at", 0))
+                        ages.append(age)
+                        if age > _d.META_STALE_AFTER:
+                            stale_count += 1
+                    except (OSError, ValueError, json.JSONDecodeError):
+                        stale_count += 1
+                if stale_count == 0 and ages:
+                    _line("daemon", f"pid {pid} alive  {len(sids)} session(s)  freshest {min(ages):.1f}s", ok=True)
                 else:
-                    _line("daemon", _red(f"pid {pid} alive but rendered.ansi is {age:.1f}s old (stale > {stale}s)"), ok=False)
-            except (OSError, ValueError, json.JSONDecodeError) as e:
-                _line("daemon", _red(f"pid {pid} alive but meta unreadable: {e}"), ok=False)
+                    _line("daemon", _red(f"pid {pid} alive  {len(sids)} session(s)  {stale_count} STALE"), ok=False)
         else:
             _line("daemon", _red(f"pidfile says {pid} but process is gone — run: cs daemon stop"), ok=False)
     except Exception as e:

--- a/src/claude_statusbar/render_thin.py
+++ b/src/claude_statusbar/render_thin.py
@@ -28,14 +28,26 @@ from pathlib import Path
 # Same constants as daemon.py — keep in sync. Duplicated rather than
 # imported so the happy path doesn't pull daemon.py in.
 _CACHE_DIR = Path.home() / ".cache" / "claude-statusbar"
-_RENDERED = _CACHE_DIR / "rendered.ansi"
-_META = _CACHE_DIR / "rendered.meta.json"
+_SESSIONS_DIR = _CACHE_DIR / "sessions"
 _STALE_AFTER_DEFAULT = 5.0  # seconds
 
 
-def _read_meta() -> dict | None:
+def _sanitize_session_id(sid: str) -> str:
+    """Same sanitisation as daemon.session_dir(). Duplicated to keep this
+    module dependency-free."""
+    safe = "".join(c for c in (sid or "default") if c.isalnum() or c in "-_")[:64]
+    return safe or "default"
+
+
+def _session_paths(sid: str) -> tuple[Path, Path, Path]:
+    """Return (stdin, rendered, meta) for one session bucket."""
+    d = _SESSIONS_DIR / _sanitize_session_id(sid)
+    return d / "last_stdin.json", d / "rendered.ansi", d / "rendered.meta.json"
+
+
+def _read_meta(meta_path: Path) -> dict | None:
     try:
-        return json.loads(_META.read_text(encoding="utf-8"))
+        return json.loads(meta_path.read_text(encoding="utf-8"))
     except (OSError, ValueError, json.JSONDecodeError):
         return None
 
@@ -60,16 +72,19 @@ def _is_fresh(meta: dict) -> bool:
     return delta <= stale_after
 
 
-_LAST_STDIN_CACHE = _CACHE_DIR / "last_stdin.json"
+# Legacy single-file path: still written for backward compat (old tooling
+# / cs doctor / preview that look at top-level last_stdin.json), but the
+# daemon reads from per-session paths now.
+_LEGACY_STDIN_CACHE = _CACHE_DIR / "last_stdin.json"
 
 
 def _consume_stdin() -> bytes | None:
     """Read Claude Code's stdin payload (bytes) and return it.
 
     Returns None if stdin is interactive or empty. Caller is responsible
-    for both (a) writing it to last_stdin.json so the daemon sees it on
-    the next tick, and (b) replaying it into sys.stdin if the inline
-    fallback path needs to consume it.
+    for both (a) writing it to per-session + legacy last_stdin.json so the
+    daemon sees it on the next tick, and (b) replaying it into sys.stdin
+    if the inline fallback path needs to consume it.
     """
     try:
         if sys.stdin.isatty():
@@ -83,30 +98,45 @@ def _consume_stdin() -> bytes | None:
     return data or None
 
 
-def _persist_stdin_bytes(data: bytes) -> None:
-    """Atomic write of raw bytes to last_stdin.json. No JSON parse — the
-    daemon validates on its next tick. ~1ms cost, never fatal.
-
-    Why we MUST do this: Claude Code injects the *current* model +
-    rate_limits + transcript path on every statusline invocation. The
-    daemon re-reads last_stdin.json to pick up changes. Without this
-    forwarding step, the daemon would be permanently stuck on whatever
-    snapshot was captured the last time `core.main()` ran — token
-    counters and 7d% would freeze the moment fast-mode was enabled.
-    """
+def _extract_session_id(payload: bytes) -> str:
+    """Pull session_id out of the JSON payload. Falls back to "default" if
+    the payload is malformed or doesn't include one (e.g. very old Claude
+    Code versions). Cost: one json.loads call (~0.05ms for typical payload)."""
     try:
-        _CACHE_DIR.mkdir(parents=True, exist_ok=True)
-        # Atomic: sibling tempfile + rename. Same pattern as
-        # cache.atomic_write_text but inlined to avoid pulling cache.py
-        # (and its imports) on the fast path.
-        tmp = _LAST_STDIN_CACHE.with_suffix(".json.thin.tmp")
+        d = json.loads(payload.decode("utf-8", errors="replace"))
+        sid = d.get("session_id") or "default"
+        return str(sid)
+    except (ValueError, json.JSONDecodeError):
+        return "default"
+
+
+def _atomic_write_bytes(target: Path, data: bytes) -> None:
+    """Sibling tempfile + os.replace. Inlined so the fast path doesn't
+    need to import cache.atomic_write_text."""
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(target.suffix + ".thin.tmp")
         with open(tmp, "wb") as f:
             f.write(data)
             f.flush()
             os.fsync(f.fileno())
-        os.replace(tmp, _LAST_STDIN_CACHE)
+        os.replace(tmp, target)
     except OSError:
         pass
+
+
+def _persist_stdin_bytes(data: bytes, session_id: str) -> None:
+    """Write the stdin payload to BOTH the per-session bucket (so daemon
+    renders this session) AND the legacy top-level file (for cs doctor /
+    preview / inline fallback compatibility).
+
+    Why per-session: multiple Claude Code windows used to overwrite each
+    other's last_stdin.json, making the daemon flip-flop. Per-session
+    paths keep them isolated.
+    """
+    session_stdin = _SESSIONS_DIR / _sanitize_session_id(session_id) / "last_stdin.json"
+    _atomic_write_bytes(session_stdin, data)
+    _atomic_write_bytes(_LEGACY_STDIN_CACHE, data)
 
 
 def _spawn_daemon_async() -> None:
@@ -134,20 +164,25 @@ def render() -> int:
     """Main entry point for ``cs render``.
 
     Returns the exit code; mirrors how the legacy `cs` invocation behaved.
-    """
-    # Capture Claude Code's stdin payload first. Both paths need it:
-    #   - fast path: write to last_stdin.json so daemon's next tick is fresh
-    #   - fallback: same write + replay into sys.stdin for core.main()
-    payload = _consume_stdin()
-    if payload is not None:
-        _persist_stdin_bytes(payload)
 
-    # Fast path: if daemon's output is fresh, cat the file and return.
-    # No core/styles/themes import.
-    meta = _read_meta()
+    Multi-session safe (v3.3.0+): each Claude Code window's session_id
+    routes to its own bucket in ~/.cache/claude-statusbar/sessions/<sid>/.
+    Two windows side by side never overwrite each other's rendered.ansi.
+    """
+    # Capture Claude Code's stdin payload, route to per-session bucket.
+    payload = _consume_stdin()
+    session_id = "default"
+    if payload is not None:
+        session_id = _extract_session_id(payload)
+        _persist_stdin_bytes(payload, session_id)
+
+    # Fast path: if THIS session's daemon-rendered output is fresh, cat
+    # the file and return. No core/styles/themes import.
+    _, rendered_path, meta_path = _session_paths(session_id)
+    meta = _read_meta(meta_path)
     if meta is not None and _is_fresh(meta):
         try:
-            sys.stdout.write(_RENDERED.read_text(encoding="utf-8"))
+            sys.stdout.write(rendered_path.read_text(encoding="utf-8"))
             return 0
         except OSError:
             # rendered.ansi disappeared between the meta read and the read.

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -55,16 +55,55 @@ def test_is_alive_for_dead_pid():
 
 
 # ---------------------------------------------------------------------------
-# Atomic publish / meta freshness
+# Per-session render (v3.3.0+)
 # ---------------------------------------------------------------------------
-def test_publish_writes_both_files(monkeypatch, tmp_path: Path):
+def test_render_session_writes_per_session_files(monkeypatch, tmp_path: Path):
+    """_render_session must write rendered.ansi + meta.json into the
+    per-session subdir, not the legacy top-level paths."""
     monkeypatch.setattr(_d, "_cache_dir", lambda: tmp_path)
-    _d._publish("hello world")
-    assert (tmp_path / "rendered.ansi").read_text(encoding="utf-8") == "hello world\n"
-    meta = json.loads((tmp_path / "rendered.meta.json").read_text(encoding="utf-8"))
-    assert meta["pid"] == os.getpid()
-    assert meta["stale_after_seconds"] == _d.META_STALE_AFTER
-    assert abs(meta["generated_at"] - time.time()) < 5.0
+    sid = "abcd-1234"
+    sdir = tmp_path / "sessions" / sid
+    sdir.mkdir(parents=True)
+    (sdir / "last_stdin.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(_d, "_render_payload", lambda payload: "FAKE LINE")
+
+    assert _d._render_session(sid) is True
+    rendered = sdir / "rendered.ansi"
+    meta = sdir / "rendered.meta.json"
+    assert rendered.read_text() == "FAKE LINE\n"
+    m = json.loads(meta.read_text())
+    assert m["session_id"] == sid
+    assert m["pid"] == os.getpid()
+
+
+def test_active_sessions_lists_recent_buckets(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(_d, "_cache_dir", lambda: tmp_path)
+    sroot = tmp_path / "sessions"
+    sroot.mkdir(parents=True)
+    fresh = sroot / "fresh-sid"
+    fresh.mkdir()
+    (fresh / "last_stdin.json").write_text("{}", encoding="utf-8")
+    # Stale: mtime > GC threshold
+    stale = sroot / "stale-sid"
+    stale.mkdir()
+    p = stale / "last_stdin.json"
+    p.write_text("{}", encoding="utf-8")
+    old = time.time() - (_d.SESSION_GC_AFTER_S + 60)
+    os.utime(p, (old, old))
+
+    sids = _d._active_sessions()
+    assert "fresh-sid" in sids
+    assert "stale-sid" not in sids
+
+
+def test_session_dir_sanitises_session_id(monkeypatch, tmp_path: Path):
+    """Defensive: a malicious session_id with path traversal must not
+    escape sessions/ directory."""
+    monkeypatch.setattr(_d, "_cache_dir", lambda: tmp_path)
+    d = _d.session_dir("../../etc/passwd")
+    # Result must be inside sessions/, not the literal traversal path.
+    assert (tmp_path / "sessions") in d.parents
 
 
 # ---------------------------------------------------------------------------
@@ -87,34 +126,42 @@ def test_thin_client_handles_missing_fields():
     assert render_thin._is_fresh({"generated_at": "not-a-number"}) is False
 
 
-def test_thin_client_read_meta_missing(monkeypatch, tmp_path: Path):
-    monkeypatch.setattr(render_thin, "_META", tmp_path / "nope.json")
-    assert render_thin._read_meta() is None
+def test_thin_client_read_meta_missing(tmp_path: Path):
+    assert render_thin._read_meta(tmp_path / "nope.json") is None
 
 
-def test_thin_client_read_meta_corrupt(monkeypatch, tmp_path: Path):
+def test_thin_client_read_meta_corrupt(tmp_path: Path):
     p = tmp_path / "meta.json"
     p.write_text("not json", encoding="utf-8")
-    monkeypatch.setattr(render_thin, "_META", p)
-    assert render_thin._read_meta() is None
+    assert render_thin._read_meta(p) is None
+
+
+def _setup_session_paths(monkeypatch, tmp_path: Path):
+    """Common helper: rebase render_thin's cache + sessions root to tmp_path."""
+    monkeypatch.setattr(render_thin, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(render_thin, "_SESSIONS_DIR", tmp_path / "sessions")
+    monkeypatch.setattr(render_thin, "_LEGACY_STDIN_CACHE", tmp_path / "last_stdin.json")
 
 
 # ---------------------------------------------------------------------------
 # Thin client end-to-end: fresh daemon output → fast path (no core import)
 # ---------------------------------------------------------------------------
 def test_thin_client_fast_path_prints_rendered(monkeypatch, tmp_path: Path, capsys):
-    """When meta is fresh, cs render must just write rendered.ansi to stdout."""
-    rendered = tmp_path / "rendered.ansi"
-    meta = tmp_path / "rendered.meta.json"
-    rendered.write_text("FAKE STATUS LINE\n", encoding="utf-8")
-    meta.write_text(json.dumps({
+    """When meta is fresh, cs render must just write the per-session
+    rendered.ansi to stdout."""
+    _setup_session_paths(monkeypatch, tmp_path)
+    sid = "test-session"
+    sdir = tmp_path / "sessions" / sid
+    sdir.mkdir(parents=True)
+    (sdir / "rendered.ansi").write_text("FAKE STATUS LINE\n", encoding="utf-8")
+    (sdir / "rendered.meta.json").write_text(json.dumps({
         "generated_at": time.time(),
         "stale_after_seconds": 5.0,
         "pid": 9999,
     }), encoding="utf-8")
-    monkeypatch.setattr(render_thin, "_RENDERED", rendered)
-    monkeypatch.setattr(render_thin, "_META", meta)
-    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: None)
+
+    payload = json.dumps({"session_id": sid}).encode()
+    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: payload)
 
     rc = render_thin.render()
     out = capsys.readouterr().out
@@ -122,46 +169,50 @@ def test_thin_client_fast_path_prints_rendered(monkeypatch, tmp_path: Path, caps
     assert out == "FAKE STATUS LINE\n"
 
 
-def test_thin_client_forwards_stdin_to_cache(monkeypatch, tmp_path: Path, capsys):
-    """Critical Phase B regression: the thin client MUST persist stdin so
-    the daemon sees fresh rate_limits on its next tick. Without this the
-    7d% / 5h% counters freeze the moment fast-mode is enabled."""
-    rendered = tmp_path / "rendered.ansi"
-    meta = tmp_path / "rendered.meta.json"
-    cache = tmp_path / "last_stdin.json"
-    rendered.write_text("X\n", encoding="utf-8")
-    meta.write_text(json.dumps({
-        "generated_at": time.time(),
-        "stale_after_seconds": 5.0,
-    }), encoding="utf-8")
-    monkeypatch.setattr(render_thin, "_RENDERED", rendered)
-    monkeypatch.setattr(render_thin, "_META", meta)
-    monkeypatch.setattr(render_thin, "_CACHE_DIR", tmp_path)
-    monkeypatch.setattr(render_thin, "_LAST_STDIN_CACHE", cache)
+def test_thin_client_forwards_stdin_to_per_session_cache(monkeypatch, tmp_path: Path):
+    """v3.3.0 critical: the thin client must persist stdin to PER-SESSION
+    last_stdin.json so the daemon renders this session's data, not whatever
+    other window most recently called cs render."""
+    _setup_session_paths(monkeypatch, tmp_path)
+    sid_a = "session-aaa"
+    sid_b = "session-bbb"
 
-    fresh_payload = b'{"rate_limits": {"seven_day": {"used_percentage": 79}}}'
-    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: fresh_payload)
+    payload_a = json.dumps({"session_id": sid_a, "marker": "A"}).encode()
+    payload_b = json.dumps({"session_id": sid_b, "marker": "B"}).encode()
 
+    monkeypatch.setattr(render_thin, "_spawn_daemon_async", lambda: None)
+    monkeypatch.setattr(render_thin, "_fallback_inline", lambda: 0)
+
+    # Simulate window A then window B both calling cs render.
+    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: payload_a)
     render_thin.render()
-    assert cache.exists(), "thin client must write stdin to last_stdin.json"
-    assert cache.read_bytes() == fresh_payload
+    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: payload_b)
+    render_thin.render()
+
+    # Both must have their own bucket; B did NOT overwrite A's stdin.
+    a_stdin = tmp_path / "sessions" / sid_a / "last_stdin.json"
+    b_stdin = tmp_path / "sessions" / sid_b / "last_stdin.json"
+    assert a_stdin.read_bytes() == payload_a, (
+        "session A's stdin was overwritten — multi-session race not fixed"
+    )
+    assert b_stdin.read_bytes() == payload_b
 
 
 def test_thin_client_fallback_when_meta_stale(monkeypatch, tmp_path: Path):
     """Stale meta → must NOT use rendered.ansi, must call inline fallback."""
-    rendered = tmp_path / "rendered.ansi"
-    meta = tmp_path / "rendered.meta.json"
-    rendered.write_text("STALE GARBAGE\n", encoding="utf-8")
-    meta.write_text(json.dumps({
-        "generated_at": time.time() - 60.0,  # 1 minute ago
+    _setup_session_paths(monkeypatch, tmp_path)
+    sid = "stale-sid"
+    sdir = tmp_path / "sessions" / sid
+    sdir.mkdir(parents=True)
+    (sdir / "rendered.ansi").write_text("STALE GARBAGE\n", encoding="utf-8")
+    (sdir / "rendered.meta.json").write_text(json.dumps({
+        "generated_at": time.time() - 60.0,
         "stale_after_seconds": 5.0,
     }), encoding="utf-8")
-    monkeypatch.setattr(render_thin, "_RENDERED", rendered)
-    monkeypatch.setattr(render_thin, "_META", meta)
-    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: None)
+    payload = json.dumps({"session_id": sid}).encode()
+    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: payload)
 
-    fallback_called = []
-    spawn_called = []
+    fallback_called, spawn_called = [], []
     monkeypatch.setattr(render_thin, "_fallback_inline",
                         lambda: (fallback_called.append(True), 0)[1])
     monkeypatch.setattr(render_thin, "_spawn_daemon_async",
@@ -169,13 +220,12 @@ def test_thin_client_fallback_when_meta_stale(monkeypatch, tmp_path: Path):
 
     rc = render_thin.render()
     assert rc == 0
-    assert fallback_called == [True], "stale meta should hit inline fallback"
-    assert spawn_called == [True], "stale meta should kick off lazy daemon spawn"
+    assert fallback_called == [True]
+    assert spawn_called == [True]
 
 
 def test_thin_client_fallback_when_no_meta(monkeypatch, tmp_path: Path):
-    monkeypatch.setattr(render_thin, "_RENDERED", tmp_path / "nope.ansi")
-    monkeypatch.setattr(render_thin, "_META", tmp_path / "nope.json")
+    _setup_session_paths(monkeypatch, tmp_path)
     monkeypatch.setattr(render_thin, "_consume_stdin", lambda: None)
     fallback_called = []
     monkeypatch.setattr(render_thin, "_fallback_inline",
@@ -186,13 +236,9 @@ def test_thin_client_fallback_when_no_meta(monkeypatch, tmp_path: Path):
 
 
 def test_thin_client_fallback_replays_stdin_for_core_main(monkeypatch, tmp_path: Path):
-    """When falling back to inline render, the captured stdin bytes must be
-    replayed into sys.stdin so core.main()'s parse_stdin_data() sees them."""
-    monkeypatch.setattr(render_thin, "_RENDERED", tmp_path / "nope.ansi")
-    monkeypatch.setattr(render_thin, "_META", tmp_path / "nope.json")
-    monkeypatch.setattr(render_thin, "_CACHE_DIR", tmp_path)
-    monkeypatch.setattr(render_thin, "_LAST_STDIN_CACHE", tmp_path / "ls.json")
-    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: b'{"hello": "world"}')
+    _setup_session_paths(monkeypatch, tmp_path)
+    payload = b'{"session_id": "x", "hello": "world"}'
+    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: payload)
     monkeypatch.setattr(render_thin, "_spawn_daemon_async", lambda: None)
 
     seen = {}
@@ -202,9 +248,17 @@ def test_thin_client_fallback_replays_stdin_for_core_main(monkeypatch, tmp_path:
     monkeypatch.setattr(render_thin, "_fallback_inline", fake_inline)
 
     render_thin.render()
-    assert seen["stdin"] == '{"hello": "world"}', (
+    assert seen["stdin"] == payload.decode(), (
         f"fallback path must see replayed stdin; got {seen.get('stdin')!r}"
     )
+
+
+def test_extract_session_id_handles_missing_field():
+    """Old Claude Code versions or malformed payloads → fall back to "default"
+    bucket so the daemon still renders something."""
+    assert render_thin._extract_session_id(b"{}") == "default"
+    assert render_thin._extract_session_id(b"not-json") == "default"
+    assert render_thin._extract_session_id(b'{"session_id": "abc-123"}') == "abc-123"
 
 
 # ---------------------------------------------------------------------------
@@ -306,7 +360,7 @@ def test_running_global_is_reset_per_run_forever_call(monkeypatch, tmp_path: Pat
     We don't actually loop here — we just verify the flag gets reset.
     """
     monkeypatch.setattr(_d, "_cache_dir", lambda: tmp_path)
-    monkeypatch.setattr(_d, "_render_once", lambda: None)  # nothing to publish
+    monkeypatch.setattr(_d, "_render_all_sessions", lambda: 0)
 
     _d._running = False  # simulate previous shutdown
     # Patch acquire to fail immediately so run_forever returns without
@@ -353,15 +407,12 @@ def test_ensure_statusline_preserves_fast_mode(tmp_path: Path, monkeypatch):
     )
 
 
-def test_render_once_captures_stdout(monkeypatch, tmp_path: Path):
-    """Daemon's _render_once must capture core.main()'s stdout into a string.
+def test_render_payload_captures_stdout(monkeypatch):
+    """Daemon's _render_payload must capture core.main()'s stdout into a string.
 
     If core.main ever stops printing (e.g., switches to logging), the daemon
     would silently produce empty output. This test pins the contract.
     """
-    monkeypatch.setattr(_d, "_cache_dir", lambda: tmp_path)
-    (tmp_path / "last_stdin.json").write_text("{}", encoding="utf-8")
-
     captured_kwargs = {}
 
     def fake_core_main(**kwargs):
@@ -372,7 +423,7 @@ def test_render_once_captures_stdout(monkeypatch, tmp_path: Path):
     import claude_statusbar.core as core_mod
     monkeypatch.setattr(core_mod, "main", fake_core_main)
 
-    out = _d._render_once()
+    out = _d._render_payload("{}")
     assert out == "FAKE RENDERED LINE", f"capture failed; got {out!r}"
     assert captured_kwargs.get("_suppress_side_effects") is True, (
         "daemon must call core.main with _suppress_side_effects=True so it "


### PR DESCRIPTION
## Bug
With fast-mode daemon enabled and **multiple Claude Code windows open simultaneously**, all windows shared a single `~/.cache/claude-statusbar/last_stdin.json` and `rendered.ansi`. Whichever window most recently called `cs render` would overwrite the others' state.

User reported observation: cache widget jumped from `5m00s` → `7s` and back, and rate-limit % flip-flopped between sessions. This was the daemon flipping between transcripts on each tick.

## Fix
Each Claude Code `session_id` (already injected by Claude Code in the stdin payload) routes to its own bucket:

```
~/.cache/claude-statusbar/sessions/<session_id>/
    last_stdin.json       per-session stdin snapshot
    rendered.ansi         per-session daemon-rendered output
    rendered.meta.json    freshness metadata
```

Daemon iterates `_active_sessions()` each tick, renders each independently. Old session dirs (no stdin updates in 24h) are GC'd every 30 minutes. session_id values are sanitised against path-traversal.

## Live verification (macOS)
```
Window A (sid aaa, Opus 4.7, 7d 80%, 4min cache)
Window B (sid bbb, Sonnet 4.6, 7d 40%, fresh cache)

→ A render: '5h 33% | 7d 80% | Opus 4.7 | cache 1m00s'
→ B render: '5h 11% | 7d 40% | Sonnet 4.6 | cache 5m00s'
→ A render again: '5h 33% | 7d 80% | Opus 4.7 | cache 58s'  ← isolated, ticking down
```

`cs daemon status` now lists per-session freshness. `cs doctor` summarises 'N session(s), freshest Xs'.

## Backward compat
- Inline mode unchanged.
- Legacy top-level `last_stdin.json` still written by thin client (so `cs doctor` / `cs preview` still see latest payload).
- Old single-bucket installs auto-migrate: first `cs render` after upgrade populates per-session bucket.
- Missing session_id (very old Claude Code) → falls back to "default" bucket.

## Tests
242 → 249 passing (+7):
- `_render_session` writes per-session files
- `_active_sessions` filters by mtime, drops stale buckets
- `session_dir` sanitises path-traversal
- thin-client per-session fast path
- thin-client persists stdin per-session (NOT shared) — the regression test
- `_extract_session_id` handles missing field / malformed JSON
- existing thin-client tests refactored to per-session API
