### PR TITLE
fix: codex review v3.3.0 follow-up (v3.3.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-statusbar",
   "description": "Lightweight Claude Code status-line monitor with switchable styles, themes, and slash commands. v3.2 adds daemon fast-mode (`cs --setup --fast`) for ~5× lower CPU at refreshInterval=1. Requires the `cs` CLI from PyPI (`pip install claude-statusbar` or `uv tool install claude-statusbar`).",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "author": {
     "name": "leeguooooo",
     "email": "leeguooooo@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-statusbar"
-version = "3.3.2"
+version = "3.3.3"
 authors = [
     {name = "leeguooooo", email = "leeguooooo@gmail.com"}
 ]

--- a/src/claude_statusbar/daemon.py
+++ b/src/claude_statusbar/daemon.py
@@ -93,13 +93,6 @@ def session_meta_path(session_id: str) -> Path:
     return session_dir(session_id) / "rendered.meta.json"
 
 
-# Legacy: kept for inline-mode compatibility (cs without `render` subcmd
-# still writes here via parse_stdin_data). Not used by the daemon's
-# per-session render loop.
-def rendered_path() -> Path: return _cache_dir() / "rendered.ansi"
-def meta_path() -> Path: return _cache_dir() / "rendered.meta.json"
-
-
 SESSION_GC_AFTER_S = 24 * 60 * 60  # drop session dirs idle > 1 day
 
 
@@ -220,21 +213,55 @@ def _process_is_our_daemon(pid: int) -> bool:
 # ---------------------------------------------------------------------------
 # Render — capture core.main()'s stdout into a string
 # ---------------------------------------------------------------------------
+RENDER_TIMEOUT_S = 12  # cap per-session render so a slow JSONL scan can't
+                       # starve other sessions. Larger than core's internal
+                       # 10s subprocess timeout so the inner cap fires first.
+
+
+class _RenderTimeout(Exception):
+    """Raised by the SIGALRM handler when a single render exceeds RENDER_TIMEOUT_S."""
+
+
+def _alarm_handler(_signum, _frame):
+    raise _RenderTimeout()
+
+
 def _render_payload(payload: str) -> Optional[str]:
     """Run core.main() with the given JSON payload as stdin and capture the
-    rendered ANSI string. Used by the per-session render loop below."""
+    rendered ANSI string. Used by the per-session render loop below.
+
+    Hard timeout: signal.alarm caps each render at RENDER_TIMEOUT_S so one
+    pathological session (e.g. multi-GB JSONL on slow NFS) can't starve the
+    others. Daemon is POSIX-only; on Windows signal.alarm doesn't exist and
+    we silently skip the timeout.
+    """
     buf = io.StringIO()
     saved_stdin = sys.stdin
     sys.stdin = io.StringIO(payload)
+
+    have_alarm = hasattr(signal, "SIGALRM")
+    old_handler = None
+    if have_alarm:
+        old_handler = signal.signal(signal.SIGALRM, _alarm_handler)
+        signal.alarm(RENDER_TIMEOUT_S)
+
     try:
         with contextlib.redirect_stdout(buf):
             from .core import main as core_main
             core_main(_suppress_side_effects=True)
+    except _RenderTimeout:
+        _log(f"render timed out after {RENDER_TIMEOUT_S}s")
+        return None
     except Exception as e:
         _log(f"render failed: {e!r}")
         return None
     finally:
+        if have_alarm:
+            signal.alarm(0)
+            if old_handler is not None:
+                signal.signal(signal.SIGALRM, old_handler)
         sys.stdin = saved_stdin
+
     out = buf.getvalue().rstrip("\n")
     return out or None
 
@@ -360,8 +387,11 @@ def run_forever(render_interval: float = DEFAULT_RENDER_INTERVAL) -> int:
 
     _log(f"daemon started pid={os.getpid()} interval={render_interval}s")
 
-    last_gc = 0.0
     GC_INTERVAL_S = 60 * 30  # garbage-collect stale session dirs every 30 min
+    # Defer first GC by one full interval — without this the first tick of
+    # every fresh daemon would scan the sessions tree, potentially racing
+    # with a Claude Code window that's mid-restart.
+    last_gc = time.time()
     try:
         while _running:
             t0 = time.time()

--- a/src/claude_statusbar/render_thin.py
+++ b/src/claude_statusbar/render_thin.py
@@ -100,26 +100,39 @@ def _consume_stdin() -> bytes | None:
 
 def _extract_session_id(payload: bytes) -> str:
     """Pull session_id out of the JSON payload. Falls back to "default" if
-    the payload is malformed or doesn't include one (e.g. very old Claude
-    Code versions). Cost: one json.loads call (~0.05ms for typical payload)."""
+    the payload is malformed, missing the field, or has a non-string value
+    (e.g. null, 0, or a future Claude Code that nests it differently).
+
+    Explicit type check prevents falsy-but-valid values like the integer 0
+    from collapsing onto the "default" bucket via `or` short-circuit.
+    Cost: one json.loads call (~0.05ms for typical payload).
+    """
     try:
         d = json.loads(payload.decode("utf-8", errors="replace"))
-        sid = d.get("session_id") or "default"
-        return str(sid)
     except (ValueError, json.JSONDecodeError):
         return "default"
+    sid = d.get("session_id") if isinstance(d, dict) else None
+    if not isinstance(sid, str) or not sid.strip():
+        return "default"
+    return sid
 
 
 def _atomic_write_bytes(target: Path, data: bytes) -> None:
     """Sibling tempfile + os.replace. Inlined so the fast path doesn't
-    need to import cache.atomic_write_text."""
+    need to import cache.atomic_write_text.
+
+    No fsync: this writes the stdin snapshot at 1 Hz per window. Crash
+    durability isn't worth the ~5-15ms penalty on slow / network FS —
+    if we lose the snapshot, the very next tick writes a fresh one.
+    The daemon's rendered.ansi write (in cache.atomic_write_text) keeps
+    fsync because that file is consumed by potentially many readers.
+    """
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
         tmp = target.with_suffix(target.suffix + ".thin.tmp")
         with open(tmp, "wb") as f:
             f.write(data)
             f.flush()
-            os.fsync(f.fileno())
         os.replace(tmp, target)
     except OSError:
         pass

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -261,6 +261,107 @@ def test_extract_session_id_handles_missing_field():
     assert render_thin._extract_session_id(b'{"session_id": "abc-123"}') == "abc-123"
 
 
+def test_extract_session_id_rejects_non_string_types():
+    """S3 from codex review: explicit type check prevents falsy-but-valid
+    integer/null session_ids from collapsing into 'default' silently."""
+    assert render_thin._extract_session_id(b'{"session_id": null}') == "default"
+    assert render_thin._extract_session_id(b'{"session_id": 0}') == "default"
+    assert render_thin._extract_session_id(b'{"session_id": ""}') == "default"
+    assert render_thin._extract_session_id(b'{"session_id": "   "}') == "default"
+    assert render_thin._extract_session_id(b'{"session_id": ["a"]}') == "default"
+
+
+# ---------------------------------------------------------------------------
+# Codex review S4: cross-session content isolation
+# ---------------------------------------------------------------------------
+def test_thin_client_serves_correct_session_when_multiple_exist(
+    monkeypatch, tmp_path: Path, capsys
+):
+    """The most critical property of v3.3.0: when sessions A and B both
+    have fresh rendered.ansi files, calling render() with payload A must
+    return A's content, not B's."""
+    _setup_session_paths(monkeypatch, tmp_path)
+    sid_a, sid_b = "sess-aaa", "sess-bbb"
+    for sid, content in [(sid_a, "AAA STATUS"), (sid_b, "BBB STATUS")]:
+        sdir = tmp_path / "sessions" / sid
+        sdir.mkdir(parents=True)
+        (sdir / "rendered.ansi").write_text(content + "\n", encoding="utf-8")
+        (sdir / "rendered.meta.json").write_text(json.dumps({
+            "generated_at": time.time(),
+            "stale_after_seconds": 5.0,
+        }), encoding="utf-8")
+
+    # Render with session A's payload — must see AAA, not BBB.
+    monkeypatch.setattr(render_thin, "_consume_stdin",
+                        lambda: json.dumps({"session_id": sid_a}).encode())
+    render_thin.render()
+    out_a = capsys.readouterr().out
+    assert out_a == "AAA STATUS\n", f"session A served wrong content: {out_a!r}"
+
+    # Render with session B's payload — must see BBB, not AAA.
+    monkeypatch.setattr(render_thin, "_consume_stdin",
+                        lambda: json.dumps({"session_id": sid_b}).encode())
+    render_thin.render()
+    out_b = capsys.readouterr().out
+    assert out_b == "BBB STATUS\n", f"session B served wrong content: {out_b!r}"
+
+
+# ---------------------------------------------------------------------------
+# Codex review S5: end-to-end "default" bucket fallback
+# ---------------------------------------------------------------------------
+def test_thin_client_routes_missing_session_id_to_default_bucket(
+    monkeypatch, tmp_path: Path, capsys
+):
+    """A payload without session_id must land in sessions/default/. Pre-create
+    fresh content there; render() must serve it."""
+    _setup_session_paths(monkeypatch, tmp_path)
+    default_dir = tmp_path / "sessions" / "default"
+    default_dir.mkdir(parents=True)
+    (default_dir / "rendered.ansi").write_text("DEFAULT BUCKET LINE\n", encoding="utf-8")
+    (default_dir / "rendered.meta.json").write_text(json.dumps({
+        "generated_at": time.time(),
+        "stale_after_seconds": 5.0,
+    }), encoding="utf-8")
+
+    # Payload has no session_id → router must use "default".
+    payload = b'{"some_other_field": 1}'
+    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: payload)
+    render_thin.render()
+    out = capsys.readouterr().out
+    assert out == "DEFAULT BUCKET LINE\n", out
+
+    # And the stdin must have been persisted into sessions/default/.
+    persisted = (default_dir / "last_stdin.json").read_bytes()
+    assert persisted == payload
+
+
+# ---------------------------------------------------------------------------
+# Codex review N5: contract test — sanitize logic must NOT drift between
+# render_thin and daemon (they're duplicated to keep render_thin import-cheap)
+# ---------------------------------------------------------------------------
+def test_sanitize_session_id_contract_pinned_between_modules(monkeypatch, tmp_path: Path):
+    """If render_thin._sanitize_session_id and daemon.session_dir() ever
+    drift, the thin client writes to one path and the daemon reads from
+    another — silent breakage. Pin the contract."""
+    monkeypatch.setattr(_d, "_cache_dir", lambda: tmp_path)
+    cases = [
+        "591dc69b-f2c8-40b0-8b52-c9f09b02e22a",  # real UUID v4
+        "default",
+        "../../etc/passwd",       # traversal attempt
+        "",                       # empty
+        "a" * 200,                # very long
+        "weird@chars!?",          # punctuation
+        "with spaces here",       # spaces
+    ]
+    for sid in cases:
+        thin_safe = render_thin._sanitize_session_id(sid)
+        daemon_dir = _d.session_dir(sid)
+        assert daemon_dir.name == thin_safe, (
+            f"sanitize drift for {sid!r}: thin → {thin_safe!r}, "
+            f"daemon → {daemon_dir.name!r}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # settings.json: cs render must be recognized as ours
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses all 5 should-fix and 3 of 5 nice-to-have findings from the codex review of v3.3.0 multi-session daemon.

## Should-fix
- **S1**: removed dead `rendered_path()` / `meta_path()` helpers (zero callers; misleading docstring claimed inline-mode use)
- **S2**: per-render timeout via `signal.alarm` (12s cap). Without it one slow JSONL scan on NFS would block all sessions sequentially. POSIX-only; Windows skips
- **S3**: `_extract_session_id` explicit `isinstance(str)` + non-empty check so falsy types (null, 0, "", []) don't silently land in "default" bucket
- **S4**: NEW test `test_thin_client_serves_correct_session_when_multiple_exist` — pins the v3.3.0 bedrock property
- **S5**: NEW test `test_thin_client_routes_missing_session_id_to_default_bucket` — end-to-end fallback coverage

## Nice-to-have
- **N1**: dropped `os.fsync` from per-tick stdin snapshot. Saves ~5-15ms on slow FS. Daemon's `rendered.ansi` write keeps fsync.
- **N3**: `last_gc = time.time()` so first daemon tick doesn't immediately GC.
- **N5**: NEW contract test `test_sanitize_session_id_contract_pinned_between_modules` — pins the duplicated sanitize logic so future drift can't silently break thin-client ↔ daemon path matching.

## Skipped (with reason)
- **N2** (warn at >70 sessions): premature optimization, no observed user.
- **N4** (doctor races GC): cosmetic; existing `OSError` catch handles it gracefully.

## Codex confirmed correct (no action needed)
- Path traversal sanitisation airtight (`../../etc/passwd` → `etcpasswd`, stays in sessions/)
- UUID session_id shape passes through unchanged
- session_id at payload root, not nested
- GC + thin-client read race handled by existing `OSError` catch
- Disk growth bounded by 24h GC
- `_running` global reset works
- Inline-mode backward compat preserved

## Tests
258 → 262 passing.
