### PR TITLE
Fix/add pytest dev dep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ optimized for the realities of running ~60 renders/minute inside Claude Code's
 ```bash
 git clone https://github.com/leeguooooo/claude-code-usage-bar
 cd claude-code-usage-bar
-uv sync
+uv sync --group dev
 uv run pytest tests/             # 320+ tests, ~1.5s
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,8 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 claude_statusbar = ["*.py", "commands/*.md", "skills/**/*.md"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.2",
+]


### PR DESCRIPTION
## Summary

`pytest` was already required to run the test suite but was not declared anywhere in `pyproject.toml`, meaning contributors had to install it manually or discover the missing dep at runtime. This adds it to a `[dependency-groups] dev` section and updates the CONTRIBUTING.md quick-start to use `uv sync --group dev`, so the dev environment is explicit and self-contained without forcing `pytest` on end-users doing a plain `uv sync`.

## Test plan

- [x] `PYTHONPATH=src uv run pytest tests/` passes locally
- [ ] If touching the render path: `PYTHONPATH=src uv run pytest tests/test_import_perf.py` passes
- [ ] If touching colors / layout: `cs preview` looks right under at least 2 themes (paste before/after below)
- [ ] If touching config: docs in README + CHANGELOG updated

## Visual diff

N/A — no render, color, or layout changes.

## Checklist

- [x] Branch name describes the change (`fix/add-pytest-dev-dep`)
- [x] Commit messages follow Conventional Commits
- [ ] CHANGELOG.md updated for user-visible changes — skipped, not a user-visible change
- [x] No raw 8-color ANSI codes introduced (use `theme.s_*` / `theme.mute` / `theme.ink`)

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full guide.