### PR TITLE
fix(party): isolate complete status slot per session config

### DIFF
--- a/src/claude_statusbar/party.py
+++ b/src/claude_statusbar/party.py
@@ -8,6 +8,7 @@ reads the cwd-scoped cache written by the AgentParty CLI:
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 import re
 import time
@@ -102,6 +103,44 @@ def _read_json(path: Path) -> Dict[str, Any]:
     except (OSError, json.JSONDecodeError):
         return {}
     return data if isinstance(data, dict) else {}
+
+
+def _status_slot_for_config(
+    state_dir: Path,
+    config_file: Path,
+    config: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Read the AgentParty cache slot owned by one explicit config.
+
+    AgentParty lets several sessions share a cwd while using different
+    ``AGENTPARTY_CONFIG`` files.  Its legacy ``statusline.json`` is therefore
+    only a last-writer mirror; the authoritative per-session value lives in a
+    fingerprinted slot.  Mirror cli/src/cache-slot.ts exactly so a session
+    never combines its identity with another channel's preview/listener.
+    """
+    identity = config.get("identity")
+    if not isinstance(identity, dict):
+        return {}
+    channel = identity.get("channel_scope")
+    if not isinstance(channel, str) or not channel:
+        return {}
+
+    source: Dict[str, Any] = {
+        "channel": channel,
+        "kind": "explicit",
+        "path": str(config_file),
+    }
+    token = config.get("token")
+    if isinstance(token, str) and token:
+        token_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()[:12]
+        source["token"] = f"sha256:{token_hash}"
+    fingerprint = hashlib.sha256(json.dumps(
+        source, ensure_ascii=False, separators=(",", ":")
+    ).encode("utf-8")).hexdigest()[:16]
+    safe_channel = re.sub(r"[^a-zA-Z0-9._-]", "_", channel) or "channel"
+    return _read_json(
+        state_dir / "slots" / f"statusline-{safe_channel}-{fingerprint}.json"
+    )
 
 
 def _int_or_none(value: Any) -> Optional[int]:
@@ -356,7 +395,22 @@ def read_party_status(
     """
     now_seconds = time.time() if now is None else now
     state_dir = state_dir_for(cwd, home=home)
-    data = _read_json(state_dir / "statusline.json")
+    data: Dict[str, Any] = {}
+    session_identity: Dict[str, Any] = {}
+    if config_path:
+        config_file = Path(config_path)
+        if not config_file.is_absolute():
+            config_file = _coerce_path(cwd) / config_file
+        else:
+            config_file = _coerce_path(config_file)
+        config = _read_json(config_file)
+        candidate_identity = config.get("identity")
+        if (isinstance(candidate_identity, dict)
+                and candidate_identity.get("name")):
+            session_identity = candidate_identity
+            data = _status_slot_for_config(state_dir, config_file, config)
+    if not data:
+        data = _read_json(state_dir / "statusline.json")
     if not data:
         return None
 
@@ -366,15 +420,8 @@ def read_party_status(
         fresh = (now_seconds * 1000.0 - updated_at) <= STALE_AFTER_SECONDS * 1000
 
     identity = data.get("identity") if isinstance(data.get("identity"), dict) else {}
-    if config_path:
-        config_file = Path(config_path)
-        if not config_file.is_absolute():
-            config_file = _coerce_path(cwd) / config_file
-        config = _read_json(config_file)
-        session_identity = config.get("identity")
-        if (isinstance(session_identity, dict)
-                and session_identity.get("name")):
-            identity = session_identity
+    if session_identity:
+        identity = session_identity
     unread = _int_or_none(data.get("unread")) or 0
     last = data.get("last_message") if isinstance(data.get("last_message"), dict) else {}
     listener = data.get("listener") if isinstance(data.get("listener"), dict) else {}

--- a/tests/test_party.py
+++ b/tests/test_party.py
@@ -464,6 +464,73 @@ def test_same_workspace_sessions_resolve_their_own_identity(tmp_path, monkeypatc
     assert identities == ["agent-a", "agent-b"]
 
 
+def test_same_workspace_sessions_read_their_own_complete_status_slot(tmp_path):
+    """Channel, preview and listener must follow the session config too.
+
+    Regression: only overriding the identity still rendered the last writer's
+    channel/message/listener, producing combinations such as a leo-code-space
+    agent beside an ai-girls stale-listener warning.
+    """
+    import hashlib
+
+    cwd = tmp_path / "repo"
+    cwd.mkdir()
+    state_dir = tmp_path / "state" / workspace_id(cwd)
+    slots = state_dir / "slots"
+    slots.mkdir(parents=True)
+    (state_dir / "statusline.json").write_text(json.dumps({
+        "channel": "ai-girls",
+        "identity": {"name": "ai-girl-zim", "kind": "agent"},
+        "last_message": {"from": "wrong", "preview": "wrong channel"},
+        "listener": {"mode": "serve", "pid": 99999999},
+    }), encoding="utf-8")
+
+    config = tmp_path / "tk-zego-im.json"
+    token = "ap_session-token"
+    config.write_text(json.dumps({
+        "token": token,
+        "identity": {
+            "name": "tk-zego-im",
+            "kind": "agent",
+            "role": "agent",
+            "channel_scope": "leo-code-space",
+        },
+    }), encoding="utf-8")
+    token_fingerprint = "sha256:" + hashlib.sha256(
+        token.encode("utf-8")).hexdigest()[:12]
+    slot_key = json.dumps({
+        "channel": "leo-code-space",
+        "kind": "explicit",
+        "path": str(config),
+        "token": token_fingerprint,
+    }, separators=(",", ":"))
+    slot_fingerprint = hashlib.sha256(
+        slot_key.encode("utf-8")).hexdigest()[:16]
+    (slots / f"statusline-leo-code-space-{slot_fingerprint}.json").write_text(
+        json.dumps({
+            "channel": "leo-code-space",
+            "server": "https://agentparty.pwtk-dev.work",
+            "identity": {"name": "tk-zego-im", "kind": "agent"},
+            "unread": 6,
+            "last_message": {
+                "from": "super-admin-leo-space",
+                "preview": "headcount fix verified",
+            },
+        }), encoding="utf-8")
+
+    status = read_party_status(
+        cwd, home=tmp_path, config_path=str(config))
+
+    assert status is not None
+    assert status.channel == "leo-code-space"
+    assert status.server == "https://agentparty.pwtk-dev.work"
+    assert status.identity_name == "tk-zego-im"
+    assert status.unread == 6
+    assert status.last_from == "super-admin-leo-space"
+    assert status.last_preview == "headcount fix verified"
+    assert status.listener_present is False
+
+
 def test_missing_transcript_is_not_attached(tmp_path, monkeypatch):
     from claude_statusbar import party
     assert party.session_is_attached("/nope/nothing.jsonl", "sid") is False


### PR DESCRIPTION
## 问题
同一 cwd 的多个 Claude session 使用不同 `AGENTPARTY_CONFIG` 时，状态栏只替换 identity，却继续读取 last-writer `statusline.json` 的频道、消息摘要和 listener，导致 `leo-code-space` session 显示 `ai-girls` 状态。对应 AgentParty #547。

## 修复
- 按 AgentParty `cache-slot.ts` 契约重算当前显式 config 的 statusline slot 指纹
- 命中 slot 时整份读取 channel/server/unread/message/listener，而非只覆盖 identity
- slot 不存在时保留 legacy fallback

## 验证
- `PYTHONPATH=src uv run pytest tests/ -q`：918 passed
- 用真实 `/Users/leo/tk.com/zugo-im-chat` + `agentparty-tk-zego-im-leo-code-space.json` 读取：channel=`leo-code-space`、identity=`tk-zego-im`，不再串到 `ai-girls`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-specific status handling for AgentParty.
  * Prevented status details from being mixed between sessions sharing the same workspace.
  * Ensured channel, server, identity, unread count, message preview, sender, and listener information reflect the correct session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->