### PR TITLE
fix(party): recover persistent config after temp invite cleanup

### DIFF
--- a/src/claude_statusbar/party.py
+++ b/src/claude_statusbar/party.py
@@ -39,6 +39,10 @@ _CONFIG_QUOTED_RE = re.compile(
 _CONFIG_UNQUOTED_RE = re.compile(
     rb"AGENTPARTY_CONFIG\s*=\s*([^\s\"'\\]+)"
 )
+_SIMPLE_ASSIGNMENT_RE = re.compile(
+    rb"(?:^|\s)([A-Za-z_][A-Za-z0-9_]*)=(?:\"([^\"]*)\"|'([^']*)'|([^\s]+))"
+)
+_SIMPLE_VARIABLE_RE = re.compile(r"^\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))$")
 _SCAN_OVERLAP = 4096
 
 
@@ -295,8 +299,23 @@ def _latest_config_path(
         for pattern in (_CONFIG_QUOTED_RE, _CONFIG_UNQUOTED_RE):
             matches.extend(pattern.finditer(encoded))
         for match in sorted(matches, key=lambda item: item.start(), reverse=True):
-            candidate = Path(_expand_config_path(
-                match.group(1).decode("utf-8")))
+            raw_value = match.group(1).decode("utf-8")
+            variable = _SIMPLE_VARIABLE_RE.match(raw_value)
+            if variable:
+                name = (variable.group(1) or variable.group(2)).encode("utf-8")
+                assignments = [
+                    item for item in _SIMPLE_ASSIGNMENT_RE.finditer(
+                        encoded[:match.start()])
+                    if item.group(1) == name
+                ]
+                if assignments:
+                    assignment = assignments[-1]
+                    raw_value = next(
+                        group.decode("utf-8")
+                        for group in assignment.groups()[1:]
+                        if group is not None
+                    )
+            candidate = Path(_expand_config_path(raw_value))
             if not candidate.is_absolute() and cwd is not None:
                 candidate = _coerce_path(cwd) / candidate
             config = _read_json(candidate)
@@ -304,6 +323,14 @@ def _latest_config_path(
             if isinstance(identity, dict) and identity.get("name"):
                 return str(candidate)
     return None
+
+
+def _is_valid_session_config(path: Optional[str]) -> bool:
+    if not path:
+        return False
+    config = _read_json(Path(path))
+    identity = config.get("identity")
+    return isinstance(identity, dict) and bool(identity.get("name"))
 
 
 def session_party_context(
@@ -341,6 +368,15 @@ def session_party_context(
                    if isinstance(state.get("config_path"), str) else None)
     offset = state.get("offset")
     offset = offset if isinstance(offset, int) and 0 <= offset <= tsize else 0
+
+    # Invite bundles are often created under $TMPDIR.  Once that file is
+    # cleaned up, keeping its path forever makes read_party_status fall back
+    # to the cwd's last-writer cache and display another session's channel.
+    # Re-scan the transcript so an older still-valid persistent config can be
+    # recovered instead of pinning the dead temporary path.
+    if cached_path and not _is_valid_session_config(cached_path):
+        cached_path = None
+        offset = 0
 
     if offset == tsize and (cached_path or not was_attached):
         return SessionPartyContext(was_attached, cached_path)

--- a/tests/test_party.py
+++ b/tests/test_party.py
@@ -531,6 +531,76 @@ def test_same_workspace_sessions_read_their_own_complete_status_slot(tmp_path):
     assert status.listener_present is False
 
 
+def test_session_recovers_older_config_when_cached_temp_file_disappears(
+        tmp_path, monkeypatch):
+    """A deleted TMPDIR invite config must not stay pinned forever."""
+    from claude_statusbar import daemon as _d
+    from claude_statusbar import party
+
+    monkeypatch.setattr(_d, "_cache_dir", lambda: tmp_path / "cache")
+    cwd = tmp_path / "repo"
+    cwd.mkdir()
+    persistent = tmp_path / "persistent.json"
+    temporary = tmp_path / "temporary.json"
+    for path, name in ((persistent, "persistent-agent"),
+                       (temporary, "temporary-agent")):
+        path.write_text(json.dumps({
+            "identity": {"name": name, "kind": "agent"},
+        }), encoding="utf-8")
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text("\n".join([
+        json.dumps({
+            "type": "tool_use",
+            "command": (
+                f'AGENTPARTY_CONFIG="{persistent}" party send first'
+            ),
+        }),
+        json.dumps({
+            "type": "tool_use",
+            "command": (
+                f'AGENTPARTY_CONFIG="{temporary}" party send latest'
+            ),
+        }),
+    ]) + "\n", encoding="utf-8")
+
+    first = party.session_party_context(
+        str(transcript), "sid-temp", cwd=cwd)
+    assert first.config_path == str(temporary)
+
+    temporary.unlink()
+    recovered = party.session_party_context(
+        str(transcript), "sid-temp", cwd=cwd)
+    assert recovered.config_path == str(persistent)
+
+
+def test_session_resolves_config_through_simple_shell_variable(
+        tmp_path, monkeypatch):
+    """Real sessions commonly use ``CFG=... AGENTPARTY_CONFIG=$CFG``."""
+    from claude_statusbar import daemon as _d
+    from claude_statusbar import party
+
+    monkeypatch.setattr(_d, "_cache_dir", lambda: tmp_path / "cache")
+    cwd = tmp_path / "repo"
+    cwd.mkdir()
+    config = tmp_path / "persistent.json"
+    config.write_text(json.dumps({
+        "identity": {"name": "tk-zego-im", "kind": "agent"},
+    }), encoding="utf-8")
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text(json.dumps({
+        "type": "tool_use",
+        "command": (
+            f'cd "{cwd}" CFG="{config}" '
+            'AGENTPARTY_CONFIG="$CFG" party history leo-code-space'
+        ),
+    }) + "\n", encoding="utf-8")
+
+    context = party.session_party_context(
+        str(transcript), "sid-variable", cwd=cwd)
+
+    assert context.config_path == str(config)
+
+
 def test_missing_transcript_is_not_attached(tmp_path, monkeypatch):
     from claude_statusbar import party
     assert party.session_is_attached("/nope/nothing.jsonl", "sid") is False


### PR DESCRIPTION
## 问题
#33 修复了有效 session config 的完整 slot 隔离，但真实 #547 session 还暴露两个接续条件：

1. 先前缓存的 `$TMPDIR` config 已被 macOS 清理，marker 永久钉住死路径；
2. 恢复后的命令通常写成 `CFG=... AGENTPARTY_CONFIG="$CFG"`，旧 parser 只会把 `$CFG` 当路径，无法解析持久 config。

结果仍回退 cwd last-writer cache，继续显示错误频道。

## 修复
- cached config 失效时从 transcript 全量重扫，恢复更早/更新的有效 config
- 安全解析同一 shell command 内的简单变量赋值，不 eval shell
- 保持 config token 不渲染、不落 statusbar marker

## 验证
- `PYTHONPATH=src uv run pytest tests/ -q`：920 passed
- 对截图原始 session stdin 真渲染：`#leo-code-space · tk-zego-im · 10 unread`，不再显示 `#ai-girls / listener down / stale`。

关联：leeguooooo/AgentParty#547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session configuration detection when temporary configuration files are removed.
  * Sessions now fall back to valid earlier configuration instead of using stale cached paths.
  * Added support for resolving configuration paths assigned through simple shell variables.

* **Tests**
  * Added coverage for recovering from deleted temporary configuration files.
  * Added coverage for shell-variable-based configuration resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->