### PR TITLE
feat: Claude 桌面客户端浮窗 HUD (cs hud)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ reset timers, current model, context window, prompt-cache freshness, and
 current AgentParty channel, identity, listener, unread count, and last-message
 preview from a local cache.
 
+On the **Claude desktop app** (macOS), `cs hud` adds a floating panel with the
+same official 5h / 7d usage and your active AgentParty channels — see
+[Desktop HUD](#desktop-hud-cs-hud).
+
 ```
 5h[   27%    ]⏰1h28m →42% | 7d[   79%    ]⏰11h28m →88% | Opus 4.8(350.0k/1.0M) | cache 4m23s
 ```
@@ -30,6 +34,7 @@ Claude Code.
 - [What it shows](#what-it-shows)
 - [Claude Code vs Codex support](#claude-code-vs-codex-support)
 - [Install](#install)
+- [Desktop HUD (`cs hud`)](#desktop-hud-cs-hud)
 - [Styles & themes](#styles--themes)
 - [Configuration](#configuration-file)
 - [Fast mode (daemon)](#fast-mode--for-refreshinterval-1)
@@ -48,37 +53,17 @@ Claude Code.
 
 ## Latest release
 
-**v3.29.12** (2026-07-15) — **AgentParty status is session-correct end to end**: sessions sharing one project now read channel, identity, unread count, message preview, and listener state from their own config-owned cache slot instead of mixing those fields with the workspace's last writer.
+**Unreleased** — **Desktop HUD** (`cs hud`, macOS): a floating panel for the **Claude desktop app** showing official 5h / 7d usage + your active AgentParty channels, with launchd auto-start. See [Desktop HUD](#desktop-hud-cs-hud).
 
-**v3.29.11** (2026-07-11) — **AgentParty identity is session-correct**: two Claude Code sessions in the same project can use different `AGENTPARTY_CONFIG` files without both status bars collapsing to the last writer's agent name. Only config paths from actual shell tool calls count; paths quoted in chat do not override identity.
+**v3.29.12** (2026-07-15) — AgentParty status is session-correct end to end: sessions sharing one project read channel/identity/unread/preview/listener from their own config-owned cache slot, not the workspace's last writer.
 
-**v3.29.6** (2026-07-10) — **support docs cleanup**: the README now states the support boundary explicitly. Claude Code is the full native `statusLine` integration; Codex support is the AgentParty local status bridge and does not include OpenAI quota/session accounting.
+**v3.29.0** (2026-07-09) — AgentParty block redesign (two-line, monochrome, listening-state header) + three daemon-restart fixes.
 
-**v3.29.5** (2026-07-09) — **service daemon and AgentParty session fixes**: `cs daemon stop` and upgrade drift-kill now recognize launchd/systemd-managed daemons, pidfile cleanup no longer deletes a newer daemon owner's pidfile, and the AgentParty block is gated on session transcript evidence so unrelated windows in the same repo do not inherit another agent's channel line.
+**v3.28.0** (2026-07-09) — AgentParty / Codex bridge line (`show_party`): appends `#channel · identity · listener · unread · last message` from the local `~/.agentparty` cache.
 
-**v3.29.0** (2026-07-09) — **AgentParty block redesign + daemon-restart fixes.** The AgentParty line was unreadable (`FAINT` stacked on the dimmest grey) and always claimed `watch down`: the reader looked for `heartbeat_at` while the contract writes `heartbeat_ts`, so every live listener read as dead. Now it renders as two lines with monochrome glyphs that inherit the theme — a header that states the listening state outright, and the last message on its own line marked `●` unread / `○` read and `@` when it mentions you. Also fixes three daemon defects found while chasing "I upgraded but nothing changed": the code-drift tick burned its own 30s spawn debounce and left every session inline-rendering; `_signal_outdated_daemon` could SIGTERM a recycled PID belonging to an unrelated process; and the orphan-`.tmp` sweep + auto-update check were starved by sharing a timer seeded to daemon start (a daemon that restarts on drift never lived the 30 minutes needed to fire either).
+**v3.11.0** (2026-06-02) — rate-limit projections (`→NN%`) blending recent pace, whole-window average, and learned day/night/weekend rhythm.
 
-**v3.28.2** (2026-07-09) — **uv-tool upgrade fix**: `cs upgrade` now detects uv-tool Python symlinks correctly and selects `uv tool install --upgrade claude-statusbar`.
-
-**v3.28.1** (2026-07-09) — **upgrade/version UX fix**: `cs upgrade` upgrades the install channel that is actually running `cs` (`uv tool`, `pipx`, or plain `pip`), and `cs -v`, `cs -V`, `cs -version` all work like `cs --version`.
-
-**v3.28.0** (2026-07-09) — **AgentParty / Codex bridge line** (`show_party`, default on): when the same workspace has AgentParty local status, `cs` appends `🎈 #channel · 🤖/👤 name · 👂watch/serve · unread · last message` under the project line. This is local-only (`~/.agentparty/state/<workspaceId>/statusline.json`), uses the same cwd-scoped workspace id fixtures as AgentParty, and marks stale/down listener state instead of pretending it is live.
-
-**v3.27.0** (2026-07-03) — **IP-risk detection aligned with ip-check**: China-cloud provider detection and ban-risk threshold handling now match the ip-check.leeguoo.com classifier.
-
-**v3.11.0** (2026-06-02) — **rate-limit projections** (`show_projection`, default on): after each `⏰<reset>` timer the bar shows `→NN%`, your expected end-of-window usage. The 5h model blends recent pace, whole-window average, and a local baseline; the 7d model integrates learned coarse rhythm buckets (work hours, non-work hours, night, weekend) so a busy first day is not blindly extrapolated across the whole week. `show_forecast` remains the separate `⚠<eta>` warning chip for imminent cap hits. Plus: `context_window.used_percentage = null` handled gracefully, and the daemon only renders windows active in the last 10s.
-
-**v3.10.0** (2026-06-02) — **live-activity line** (in-progress todo, active tool, completed-tool rollup), **git ahead/behind + session duration/lines** on the project line, **running-subagent** lines, an opt-in **`bar_shimmer`** starfield on the battery bars, and a **self-hosted plugin marketplace**. Plus: auto-update now actually runs in daemon mode (detached, non-blocking), and the cache countdown is per-session-correct. All new segments are opt-in except the todo line.
-
-**v3.6.0** (2026-05-08) — **`cs --setup` now defaults to daemon (fast) mode**: under 1% CPU continuously instead of ~3% inline. Pass `--inline` to opt back. Also: py3.9 compat fixes, GitHub Actions CI, animated hero GIF.
-
-**v3.5.1** — `npx skills add` install path, `show_cache_age` on by default.
-
-**v3.5.0** — consolidated `claude-statusbar` skill: say *"switch theme to nord"* / *"余量颜色改成 #4ec85b"* and Claude Code routes it to the right `cs` command.
-
-**v3.4** — per-segment color management (each metric colors itself by its own severity), classic style finally respects themes, two new themes (`catppuccin-mocha`, `tokyo-night`), per-severity color overrides via `cs config set color_ok|warn|hot`.
-
-**v3.2** — daemon fast-mode (now the default in v3.6.0) for ~5× lower CPU at `refreshInterval=1`.
+**v3.6.0** (2026-05-08) — `cs --setup` defaults to daemon (fast) mode: under 1% CPU instead of ~3% inline.
 
 📋 **Full changelog:** [CHANGELOG.md](CHANGELOG.md) · [GitHub Releases](https://github.com/leeguooooo/claude-code-usage-bar/releases) — every version's changes, also linked from the [PyPI page](https://pypi.org/project/claude-statusbar/).
 
@@ -202,6 +187,38 @@ This installs only the skill globally. It does *not* install `cs` itself — the
 
 `cs --setup` already installs the same skill alongside the slash commands, so most users don't need this path.
 
+## Desktop HUD (`cs hud`)
+
+> **macOS only.** A floating panel that docks to the bottom-right of the **Claude
+> desktop app** — for when you live in the desktop client instead of the terminal.
+
+The desktop app has no `statusLine` hook, so the HUD is a separate always-on-top
+window. It reads the **official** 5h / 7d usage the desktop app itself samples
+every 5 minutes into `plan-usage-history.json` — the same numbers the terminal
+bar shows, not an estimate — plus your active AgentParty channels.
+
+```bash
+pip install 'claude-statusbar[hud]'   # adds PyObjC (macOS GUI deps)
+cs hud install                        # launchd: auto-start on login + keep-alive
+```
+
+- **Collapsed pill** — `5h 26% · 7d 22%` + a status dot. Click to expand.
+- **Expanded panel** — orange 5h / 7d gradient bars with reset countdowns, and a
+  scrollable list of active AgentParty channels (unread count + latest message).
+  Click a channel row to **lock** it as the one shown in the collapsed pill.
+- **Drag** it anywhere — the position is remembered. It hides itself when the
+  Claude desktop app isn't open.
+
+| Command | What it does |
+|---------|--------------|
+| `cs hud install` | Install the launchd agent — auto-start on login + crash-restart |
+| `cs hud start` | Run in the foreground (what the launchd service calls) |
+| `cs hud stop` | Stop the running HUD |
+| `cs hud uninstall` | Remove the launchd agent |
+
+Everything is local: official usage from the desktop app's own cache, AgentParty
+from `~/.agentparty/state/`. No network calls, no credentials read.
+
 ## Styles & themes
 
 The default style (`classic`) stays the same forever. Two alternative styles, plus a palette of seven themes, are opt-in.
@@ -305,33 +322,27 @@ Persisted to `~/.claude/claude-statusbar.json`:
 | Key | Values | What it does |
 |-----|--------|--------------|
 | `style` | `classic` / `capsule` / `hairline` | Layout |
-| `theme` | `graphite` / `twilight` / `linen` / `nord` / `dracula` / `sakura` / `mono` / `catppuccin-mocha` / `tokyo-night` | Colors |
-| `density` | `compact` / `regular` / `cozy` | Padding around segments (capsule + hairline only) |
-| `auto_compact_width` | integer (e.g. `100`) | Force `hairline` when terminal narrower than this. `0` = disabled |
-| `show_weekly`, `show_language` | bool | Hide individual segments |
-| `show_cost` | bool, default `false` | Append `$ X.XX` — the current session's cost as Claude Code reports it. For Pro/Max subscribers this is the **API-equivalent value** of your usage (what it would cost on the API), not money owed; many subscribers use it as a "subscription ROI" gauge. Opt-in because the "session" boundary is what Claude Code reports — not necessarily what you intuitively call one. |
-| `show_balance` | bool, default `true` | In no-quota mode only, show `bal $X.XX` — your relay account balance. A detached helper probes the relay's OpenAI-compatible billing endpoint (`/dashboard/billing/subscription` + `/usage`) with your key, computes `hard_limit − used`, and caches it (5 min; a relay that doesn't support it is remembered as unsupported for 1 h). Default on but **fully auto**: it only appears if the relay actually answers, so subscribers and unsupported relays see nothing. Set `false` to never probe. |
-| `balance_bar` | bool, default `true` | Render the balance (above) as a fuel-gauge battery `bal[████ 52%] $26.00` — fill = remaining proportion, green when full → yellow ≤25% → red ≤10%. Falls back to plain `bal $X` text when the relay reports no usable hard-limit. Set `false` to always use plain text. No effect when `show_balance` is off. |
-| `show_cache_age` | bool, default `true` | Append a `cache 4m23s` countdown to Anthropic's prompt-cache expiry, with the TTL (5min vs 1h) auto-detected from the transcript. Three-level color: green (>1min remaining), yellow (<1min), red `cache COLD` (expired). Cache hits consume ~10× less rate-limit quota — for Pro/Max subscribers, letting it go COLD eats your 5h / 7d windows ~10× faster. `cs --setup` writes `refreshInterval: 1` by default so this segment ticks visibly. Original implementation contributed by [@marcwimmer](https://github.com/marcwimmer) in [#9](https://github.com/leeguooooo/claude-code-usage-bar/pull/9). Disable with `cs config set show_cache_age false`. |
-| `cache_ttl_seconds` | int, default `300` | **Deprecated since v3.9.0.** The segment now auto-detects the real TTL (5min vs 1h) from the transcript's `cache_creation` buckets, so this value is no longer consulted. Still accepted (and `cs config set cache_ttl_seconds …` still works) so existing configs don't break. See [How the cache countdown works](#how-the-cache-countdown-works). |
-| `show_project_branch` | bool, default `true` | Append a second line `⤷ <project> ⎇ <branch>●` below the bar. Project name comes from Claude Code's `workspace.repo.name` stdin field (falls back to cwd basename); branch is read from `.git/HEAD` directly. The `●` dirty marker is refreshed by a background helper and cached 5 s — the inline render path never blocks on `git`. Disable with `cs config set show_project_branch false`. |
-| `show_party` | bool, default `true` | Append the local AgentParty/Codex bridge line when `~/.agentparty/state/<workspaceId>/statusline.json` exists for the current workspace. Shows channel, identity kind/name, listener mode, unread count, and last-message preview. Local-only: no AgentParty CLI call, no token read, no network. Disable with `cs config set show_party false`. |
-| `show_ahead_behind` | bool, default `false` | Append a `↑2↓1` commits-ahead/behind-upstream marker after the branch on the identity line. Reuses the same cached `git status --branch` call as the dirty dot, so it adds no extra git spawn. Only takes effect when `show_project_branch` is on (it lives on that line). Arrows show only for nonzero directions; in sync → nothing. |
-| `show_todos` | bool, default `true` | Third "activity" line: the in-progress todo + `done/total`, e.g. `▸ Wire the activity line (1/3)`. Parsed from the newest `TodoWrite` in the transcript (full list, last-write-wins) via the same bounded reverse-tail read as the cache countdown. The clearest "is my long turn making progress?" signal. Disable with `cs config set show_todos false`. |
-| `show_tools` | bool, default `false` | Activity line: the **active tool** (`◐ Edit auth.py` — the newest tool_use with no result yet). MCP names are shortened (`mcp__figma__get_screenshot` → `get_screenshot`). Opt-in. |
-| `show_tool_rollup` | bool, default `false` | Activity line: a frequency rollup of recently-completed tools (`✓ Edit×14 Bash×6 Read×4`). A volume tally rather than a live signal — separate from `show_tools` and off by default. Opt-in. |
-| `bar_shimmer` | bool, default `false` | **Experimental, classic style only.** A faint twinkling starfield in the *empty* part of the 5h/7d battery bars (static high/mid/low dot field + bright `✦`/`✧` stars winking in/out). The fill color is never changed. Capped at the statusLine's ~1Hz refresh, so it's a gentle twinkle, not a smooth animation. Off by default. |
-| `show_projection` | bool, default `true` | Appends an always-visible `→NN%` projection after each 5h/7d reset timer, estimating the percentage expected at reset. The 5h model blends recent pace, whole-window average, and local baseline; the 7d model integrates learned coarse rhythm buckets (work hours, non-work hours, night, weekend) so a busy first day is not blindly extrapolated across the whole week. Disable with `cs config set show_projection false`. |
-| `show_forecast` | bool, default `true` | Controls the separate `⚠~ETA` warning chip. It appears after the projection only when a window is projected to hit 100% before reset and the cap is imminent. Disable with `cs config set show_forecast false`. |
-| `show_agents` | bool, default `false` | One **bottom line per running subagent**, e.g. `◐ explore[haiku] 探索 RsaKeyPairPool 2m15s` (multiple agents → multiple lines). Inline agents finish via their tool_result; background (`run_in_background`) agents finish via the queue-operation that carries their tool-use-id. **Off by default because Claude Code already shows background agents in its own native panel** — enabling this largely duplicates that. |
-| `show_duration` | bool, default `false` | **Identity line:** session wall-clock duration as Claude Code reports it (`⏱ 12m`). Already on stdin — no transcript scan. Shows next to the project (needs `show_project_branch` on). Opt-in. |
-| `show_lines` | bool, default `true` | **Identity line:** session lines added/removed as Claude Code reports it (`+182 -47`, +green/−red). This is Claude Code's own cumulative session tally (every Write/Edit), **not a git diff** — it can exceed the net working-tree change. Needs `show_project_branch` on. On by default; disable with `cs config set show_lines false`. |
-| `show_version` | bool, default `true` | **Identity line:** a faint `· vX.Y.Z` at the very end (darkest grey + dim attribute, so it recedes). When a newer version is on PyPI, an amber `↑<newver>` is appended (`· v3.11.2 ↑3.12.0`) — read from a local cache the background update check writes, so the render path never hits the network. Disable with `cs config set show_version false`. |
-| `show_mode` | bool, default `true` | A dedicated **`⚙` session-mode line**: `⚙ effort:high · think:on · fast:off · style:default`, straight from Claude Code's stdin (effort level / thinking / fast mode / output style). Each field is dropped when absent. Disable with `cs config set show_mode false`. |
-| `mode_gradient` | bool, default `true` | Tint the mode line with a **static gradient keyed to the effort tier** — a soft, **desaturated** cool→purple ladder matching Claude Code's own Faster→Smarter slider (low/auto teal, medium azure, high blue, xhigh indigo, max violet, **ultracode** dusty magenta) — muted so it doesn't shout next to the rest of the bar, while the hue still tells the level. Static, not animated (an external statusLine refreshes at ≤1 Hz, so motion only flickers). `cs config set mode_gradient false` → plain per-tier text colours. |
-| `api_mode` | `auto` (default) / `on` / `off` | **No-quota mode** for third-party relays & cloud backends — see below. `auto` detects from the environment; `on`/`off` force it. Per-shell override: `CS_API_MODE` env var (wins over config). |
+| `theme` | 9 themes (listed above) | Colors |
+| `density` | `compact` / `regular` / `cozy` | Segment padding (capsule + hairline only) |
+| `auto_compact_width` | int | Force `hairline` below this terminal width; `0` = off |
+| `show_cost` | bool, `false` | Append `$ X.XX` session cost (API-equivalent value for subscribers) |
+| `show_balance` / `balance_bar` | bool, `true` | No-quota relay balance as a fuel-gauge bar — auto-hidden if the relay doesn't support it |
+| `show_cache_age` | bool, `true` | `cache 4m23s` prompt-cache countdown (TTL auto-detected 5m/1h) |
+| `show_project_branch` | bool, `true` | Second line: project + branch + `●` dirty dot |
+| `show_ahead_behind` | bool, `false` | `↑2↓1` commits ahead/behind on the branch line |
+| `show_party` | bool, `true` | AgentParty / Codex bridge line (reads local cache only) |
+| `show_todos` | bool, `true` | Activity line: in-progress todo + `done/total` |
+| `show_tools` / `show_tool_rollup` | bool, `false` | Active tool / completed-tool frequency rollup |
+| `show_projection` / `show_forecast` | bool, `true` | `→NN%` projection / `⚠ETA` at-risk warning chip |
+| `show_agents` | bool, `false` | One bottom line per running subagent (Claude Code shows these natively too) |
+| `show_duration` / `show_lines` | bool | Session `⏱` duration / `+/−` lines on the identity line |
+| `show_version` | bool, `true` | Faint `· vX.Y.Z` (+ amber `↑newver` when a newer PyPI release exists) |
+| `show_mode` / `mode_gradient` | bool, `true` | `⚙` session-mode line + effort-tier gradient tint |
+| `show_weekly` / `show_language` | bool | Toggle the 7d bar / language-coach segment |
+| `bar_shimmer` | bool, `false` | Experimental twinkling starfield on bars (classic only) |
+| `api_mode` | `auto` / `on` / `off` | No-quota mode (see below); `CS_API_MODE` env overrides |
 
-Set via `cs config set <key> <value>`. Wipe everything back to defaults with `cs config reset`.
+Full per-key detail is in the [segment table above](#what-it-shows) or `cs config show`. Set with `cs config set <key> <value>`; `cs config reset` restores defaults.
 
 ## No-quota mode (third-party relay / Bedrock / Vertex)
 
@@ -529,44 +540,7 @@ flowchart TD
     style CO fill:#fbeceb,stroke:#e0443d,color:#8f2723
 ```
 
-It's a couple dozen lines and not Claude-Code-specific — `message.usage.cache_creation` is a standard Claude API field, so you can reuse the logic in your own status bar, plugin, or script:
-
-```text
-# prompt-cache countdown. input: path to the current session transcript (JSONL).
-# three things to get right:
-#   1. anchor the most recent assistant entry (not the user message, not file mtime)
-#   2. read the TTL from the cache_creation buckets — don't hard-code it
-#   3. read the file tail only, don't slurp the whole thing
-
-function cacheCountdown(transcriptPath):
-    age = null            # seconds, from the newest assistant entry's timestamp
-    ttl = null            # seconds, from the newest entry that WROTE cache
-
-    # reverse-read the tail, at most 320KB (32KB chunks); grab age + ttl in one pass
-    for entry in reversedJsonlEntries(transcriptPath, maxBytes = 320 * 1024):
-        if entry.type != "assistant": continue
-        if age is null and entry.timestamp:
-            age = now() - parseTimeUTC(entry.timestamp)   # treat naive timestamps as UTC
-        if ttl is null:
-            cc = entry.message.usage.cache_creation
-            if   cc.ephemeral_1h_input_tokens > 0: ttl = 3600
-            elif cc.ephemeral_5m_input_tokens > 0: ttl = 300
-        if age is not null and ttl is not null: break
-
-    if age is null:  return "COLD"     # no assistant entry
-    if ttl is null:  ttl = 300         # no cache-write signal -> conservative fallback
-    if age < 0:      age = 0           # clock skew / future timestamp -> clamp to 0
-
-    remaining = ttl - age
-    if remaining <= 0: return "COLD"
-    return formatCountdown(ceil(remaining))
-
-# always show seconds so the number visibly ticks (proof it's live, not stuck)
-function formatCountdown(s):
-    if s >= 3600: return "{h}h{mm}m{ss}s"   # 1h59m03s
-    if s >= 60:   return "{m}m{ss}s"         # 58m23s / 4m07s
-    return "{s}s"                            # 47s (< 1min)
-```
+The logic is a couple dozen lines and not Claude-Code-specific — `message.usage.cache_creation` is a standard Claude API field, so you can reuse it in your own status bar or script. See [`activity.py`](src/claude_statusbar/activity.py) for the implementation: reverse-tail the transcript (≤ 320 KB), anchor the newest `assistant` entry's timestamp for `age`, read the TTL from its `cache_creation` bucket (1h → 3600, 5m → 300), then `remaining = TTL − age` (COLD when ≤ 0).
 
 **Deep dive** — how accurate it really is, plus the Feb→May 2026 cache-TTL saga (1h → 5m → 1h) with sources: [状态栏那行 cache 4m23s，到底准不准？ (Chinese)](https://blog.misonote.com/zh/posts/claude-statusbar-cache-countdown/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,11 @@ dependencies = []
 full = [
     "claude-monitor>=3.0.0",
 ]
+# Desktop floating HUD (macOS only): `cs hud`. Requires PyObjC.
+hud = [
+    "pyobjc-framework-Cocoa>=10.0; sys_platform == 'darwin'",
+    "pyobjc-framework-Quartz>=10.0; sys_platform == 'darwin'",
+]
 
 [project.urls]
 Homepage = "https://github.com/leeguooooo/claude-code-usage-bar"

--- a/src/claude_statusbar/cli.py
+++ b/src/claude_statusbar/cli.py
@@ -23,6 +23,7 @@ SUBCOMMANDS = (
     "doctor",
     "daemon",
     "upgrade",
+    "hud",
 )
 
 
@@ -196,6 +197,97 @@ def _run_upgrade_subcommand():
     return 0 if ok else 1
 
 
+HUD_LABEL = "com.leeguoo.claude-statusbar-hud"
+
+
+def _hud_plist_path():
+    from pathlib import Path
+    return Path.home() / "Library/LaunchAgents" / f"{HUD_LABEL}.plist"
+
+
+def _hud_program_args():
+    import shutil
+    cs = shutil.which("cs") or shutil.which("claude-statusbar")
+    return [cs, "hud", "start"] if cs else [sys.executable, "-m", "claude_statusbar.cli", "hud", "start"]
+
+
+def _hud_install():
+    from pathlib import Path
+    import subprocess
+    plist = _hud_plist_path()
+    plist.parent.mkdir(parents=True, exist_ok=True)
+    log = str(Path.home() / ".claude" / "claude-statusbar-hud.log")
+    args = "".join(f"    <string>{a}</string>\n" for a in _hud_program_args())
+    plist.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" '
+        '"http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
+        '<plist version="1.0">\n<dict>\n'
+        f'  <key>Label</key><string>{HUD_LABEL}</string>\n'
+        f'  <key>ProgramArguments</key>\n  <array>\n{args}  </array>\n'
+        '  <key>RunAtLoad</key><true/>\n  <key>KeepAlive</key><true/>\n'
+        f'  <key>StandardErrorPath</key><string>{log}</string>\n'
+        f'  <key>StandardOutPath</key><string>{log}</string>\n'
+        '</dict>\n</plist>\n',
+        encoding="utf-8",
+    )
+    subprocess.run(["launchctl", "unload", str(plist)], capture_output=True)
+    r = subprocess.run(["launchctl", "load", str(plist)], capture_output=True, text=True)
+    if r.returncode != 0:
+        print(f"launchctl load 失败: {r.stderr.strip()}", file=sys.stderr)
+        return 1
+    print(f"已安装 HUD 常驻服务 (开机自启 + 崩溃重启)\n  plist: {plist}")
+    return 0
+
+
+def _hud_uninstall():
+    import subprocess
+    plist = _hud_plist_path()
+    subprocess.run(["launchctl", "unload", str(plist)], capture_output=True)
+    if plist.exists():
+        plist.unlink()
+    subprocess.run(["pkill", "-f", "claude_statusbar.cli hud"], capture_output=True)
+    print("已卸载 HUD 常驻服务")
+    return 0
+
+
+def _hud_stop():
+    import subprocess
+    subprocess.run(["launchctl", "stop", HUD_LABEL], capture_output=True)
+    subprocess.run(["pkill", "-f", "claude_statusbar.cli hud"], capture_output=True)
+    print("已停止 HUD (若已 install,launchd 会自动重启;彻底移除用 uninstall)")
+    return 0
+
+
+def _run_hud_subcommand(rest):
+    """`cs hud [start|install|uninstall|stop]` — floating desktop HUD (macOS)."""
+    if sys.platform != "darwin":
+        print("cs hud 仅支持 macOS", file=sys.stderr)
+        return 2
+    action = rest[0] if rest else "start"
+    if action == "install":
+        return _hud_install()
+    if action == "uninstall":
+        return _hud_uninstall()
+    if action == "stop":
+        return _hud_stop()
+    if action in ("start", "run"):
+        try:
+            from . import hud
+        except ImportError as e:
+            print(
+                f"缺少 GUI 依赖 (pyobjc): {e}\n"
+                "安装: pip install 'claude-statusbar[hud]'\n"
+                "或:   pip install pyobjc-framework-Cocoa pyobjc-framework-Quartz",
+                file=sys.stderr,
+            )
+            return 1
+        hud.run(rest[1:])
+        return 0
+    print(f"未知 hud 动作: {action} (支持 start/install/uninstall/stop)", file=sys.stderr)
+    return 2
+
+
 def main():
     """Main CLI entry point"""
     # Render fast-path: `cs render` is what Claude Code calls 60×/min when
@@ -210,6 +302,8 @@ def main():
     if len(sys.argv) >= 2 and sys.argv[1] in SUBCOMMANDS:
         sub = sys.argv[1]
         rest = sys.argv[2:]
+        if sub == "hud":
+            return _run_hud_subcommand(rest)
         if sub == "daemon":
             return _run_daemon_subcommand(rest)
         if sub == "upgrade":

--- a/src/claude_statusbar/hud.py
+++ b/src/claude_statusbar/hud.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""Floating session HUD — Claude-branded design.
+
+Draggable, click-to-expand/minimize, anchored bottom-right of the Claude window.
+5h/7d official usage (plan-usage-history) + scrollable AgentParty channels.
+Visual spec mirrors the Claude Usage Panel design (warm #faf9f5 card, orange
+gradient bars, colored status dots)."""
+import sys, os, time, json
+from pathlib import Path
+import objc
+import Quartz
+from AppKit import (
+    NSApplication, NSPanel, NSColor, NSTextField, NSFont, NSScreen, NSView,
+    NSBezierPath, NSGradient,
+    NSWindowStyleMaskBorderless, NSWindowStyleMaskNonactivatingPanel,
+    NSBackingStoreBuffered, NSStatusWindowLevel,
+    NSMakeRect, NSMakePoint,
+    NSWindowCollectionBehaviorCanJoinAllSpaces, NSWindowCollectionBehaviorStationary,
+    NSWindowCollectionBehaviorFullScreenAuxiliary, NSApp,
+    NSApplicationActivationPolicyAccessory, NSEvent, NSFontWeightMedium,
+    NSFontWeightSemibold, NSFontWeightBold, NSFontWeightRegular,
+    NSLineBreakByTruncatingTail, NSTextAlignmentRight, NSTextAlignmentCenter,
+    NSMutableAttributedString, NSForegroundColorAttributeName, NSFontAttributeName,
+)
+from Foundation import NSTimer
+
+from . import hud_data as HD
+
+# ---- Claude palette ----
+def _c(hexs, a=1.0):
+    h = hexs.lstrip("#")
+    return NSColor.colorWithSRGBRed_green_blue_alpha_(
+        int(h[0:2], 16) / 255, int(h[2:4], 16) / 255, int(h[4:6], 16) / 255, a)
+
+BG      = _c("#faf9f5")
+INK     = _c("#3d3929")
+INK_Hdr = _c("#6f6b5c")
+GREY    = _c("#83827d")
+GREY2   = _c("#a6a294")
+DIVIDER = _c("#3d3929", 0.08)
+BORDER  = _c("#3d3929", 0.08)
+TRACK   = _c("#e8e5db")
+ORANGE  = _c("#c96442")
+ORANGE2 = _c("#d97757")
+GREEN   = _c("#4a8a52")
+DOT_GREEN = _c("#5cad63")
+DOT_GOLD  = _c("#e2b93b")
+DOT_RED   = _c("#8f2f2a")
+HOVER   = _c("#c96442", 0.06)
+
+SH = 22            # shadow margin around the card
+PAD = 16
+EXP_W = 384
+HEADER_H = 104     # header + usage + divider (fixed top block)
+PARTY_HDR = 30     # "AGENTPARTY" label block
+LIST_TOP = HEADER_H + PARTY_HDR
+AGENT_ROW_H = 46
+LIST_H = 172       # scrollable area height (≈3.7 rows)
+EXP_H = LIST_TOP + LIST_H + 8
+COLLAPSED_W = 190
+COLLAPSED_H = 32
+MARGIN = 14
+DATA_EVERY = 20.0
+DURATION = 0
+
+HUD_STATE_PATH = Path.home() / ".claude" / "claude-statusbar-hud.json"
+HUD_PID_PATH = Path.home() / ".claude" / "claude-statusbar-hud.pid"
+state = {"expanded": False, "u": HD.Usage(), "channels": [], "locked": None,
+         "rows": [], "scroll": 0.0, "abs": None, "last_data": 0.0}
+
+
+def load_persist():
+    try:
+        d = json.loads(HUD_STATE_PATH.read_text(encoding="utf-8"))
+        state["abs"] = d.get("abs")
+        state["locked"] = d.get("locked"); state["expanded"] = bool(d.get("expanded", False))
+    except Exception:
+        pass
+
+
+def save_persist():
+    try:
+        HUD_STATE_PATH.write_text(json.dumps({
+            "abs": state["abs"],
+            "locked": state["locked"], "expanded": state["expanded"]}), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def refresh_data(force=False):
+    if force or time.time() - state["last_data"] > DATA_EVERY:
+        state["u"] = HD.snapshot()
+        state["channels"] = HD.all_channels(top_n=12)
+        state["last_data"] = time.time()
+
+
+def dot_color(age):
+    return DOT_GREEN if age < 300 else (DOT_GOLD if age < 1800 else DOT_RED)
+
+
+def _pick_collapsed_channel():
+    chs = state["channels"]
+    if not chs:
+        return None
+    if state["locked"]:
+        for c in chs:
+            if c["key"] == state["locked"]:
+                return c
+    return chs[0]
+
+
+def _list_h():
+    return LIST_H
+
+
+def _max_scroll():
+    return max(0.0, len(state["channels"]) * AGENT_ROW_H - _list_h())
+
+
+# ---------------- custom views ----------------
+class FreePanel(objc.lookUpClass("NSPanel")):
+    # Don't let AppKit clamp the window onto a screen — it fights our fixed
+    # position at display edges and makes the HUD jitter. Allow any position.
+    def constrainFrameRect_toScreen_(self, rect, screen):
+        return rect
+
+
+class Flipped(objc.lookUpClass("NSView")):
+    def isFlipped(self):
+        return True
+
+
+class GradBar(objc.lookUpClass("NSView")):
+    def initWithFrame_pct_(self, frame, pct):
+        self = objc.super(GradBar, self).initWithFrame_(frame)
+        if self is None: return None
+        self.pct = pct or 0
+        return self
+
+    def drawRect_(self, _):
+        b = self.bounds(); rad = b.size.height / 2.0
+        TRACK.set()
+        NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(b, rad, rad).fill()
+        frac = max(0.0, min(1.0, self.pct / 100.0))
+        if frac > 0:
+            w = max(b.size.height, b.size.width * frac)
+            p = NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(
+                NSMakeRect(0, 0, w, b.size.height), rad, rad)
+            NSGradient.alloc().initWithStartingColor_endingColor_(ORANGE2, ORANGE).drawInBezierPath_angle_(p, 0.0)
+
+
+class GoldDot(objc.lookUpClass("NSView")):
+    def drawRect_(self, _):
+        b = self.bounds()
+        p = NSBezierPath.bezierPathWithOvalInRect_(b)
+        NSGradient.alloc().initWithStartingColor_endingColor_(_c("#f0d067"), _c("#e2b93b")).drawInBezierPath_relativeCenterPosition_(p, (-0.3, 0.4))
+        _c("#3d3929", 0.12).set(); p.setLineWidth_(1.0); p.stroke()
+
+
+def _lbl(parent, frame, size, weight, color, text, right=False, center=False):
+    t = NSTextField.alloc().initWithFrame_(frame)
+    t.setBezeled_(False); t.setEditable_(False); t.setSelectable_(False); t.setDrawsBackground_(False)
+    f = NSFont.systemFontOfSize_weight_(size, weight)
+    t.setFont_(f)
+    t.setTextColor_(color)
+    t.cell().setLineBreakMode_(NSLineBreakByTruncatingTail)
+    if right: t.setAlignment_(NSTextAlignmentRight)
+    if center: t.setAlignment_(NSTextAlignmentCenter)
+    t.setStringValue_(text)
+    parent.addSubview_(t)
+    return t
+
+
+def _round_view(parent, frame, color, radius):
+    v = NSView.alloc().initWithFrame_(frame)
+    v.setWantsLayer_(True)
+    v.layer().setBackgroundColor_(color.CGColor())
+    v.layer().setCornerRadius_(radius)
+    parent.addSubview_(v)
+    return v
+
+
+def _dot(parent, frame, color):
+    v = NSView.alloc().initWithFrame_(frame)
+    v.setWantsLayer_(True)
+    v.layer().setBackgroundColor_(color.CGColor())
+    v.layer().setCornerRadius_(frame.size.height / 2)
+    v.layer().setBorderWidth_(1.0)
+    v.layer().setBorderColor_(_c("#3d3929", 0.12).CGColor())
+    parent.addSubview_(v)
+    return v
+
+
+# ---------------- content ----------------
+def build_content(card):
+    for v in list(card.subviews()):
+        v.removeFromSuperview()
+    state["rows"] = []
+    u = state["u"]
+
+    if not state["expanded"]:
+        _build_collapsed(card, u); return
+    _build_expanded(card, u)
+
+
+def _build_collapsed(card, u):
+    w = COLLAPSED_W
+    fh = "–" if u.fh is None else f"{u.fh}"
+    sd = "–" if u.sd is None else f"{u.sd}"
+    # "5h 26% · 7d 17%"   + gold dot
+    s = NSMutableAttributedString.alloc().initWithString_(f"5h {fh}%    ·    7d {sd}%")
+    full = s.string()
+    def paint(sub, color, font):
+        r = full.rangeOfString_(sub)
+        if r.length:
+            s.addAttribute_value_range_(NSForegroundColorAttributeName, color, r)
+            s.addAttribute_value_range_(NSFontAttributeName, font, r)
+    f_lbl = NSFont.systemFontOfSize_weight_(12.5, NSFontWeightSemibold)
+    f_pct = NSFont.monospacedDigitSystemFontOfSize_weight_(13, NSFontWeightBold)
+    s.addAttribute_value_range_(NSFontAttributeName, f_lbl, (0, len(full)))
+    paint("5h", GREY, f_lbl); paint("7d", GREY, f_lbl)
+    paint("·", _c("#c9c5b8"), f_lbl)
+    if u.fh is not None: paint(f"{fh}%", GREEN, f_pct)
+    if u.sd is not None: paint(f"{sd}%", GREEN, f_pct)
+    lab = _lbl(card, NSMakeRect(14, 7, w - 44, 18), 12.5, NSFontWeightSemibold, GREY, "")
+    lab.setAttributedStringValue_(s)
+    d = GoldDot.alloc().initWithFrame_(NSMakeRect(w - 26, 9, 14, 14))
+    d.setWantsLayer_(True); card.addSubview_(d)
+
+
+def _build_expanded(card, u):
+    w = EXP_W
+    # ---- header ----
+    logo = _round_view(card, NSMakeRect(PAD, 14, 15, 15), ORANGE, 4)
+    _lbl(logo, NSMakeRect(0, 0, 15, 15), 9.5, NSFontWeightBold, BG, "C", center=True)
+    _lbl(card, NSMakeRect(PAD + 22, 14, 200, 15), 11, NSFontWeightSemibold, INK_Hdr, "CLAUDE 用量")
+    # minimize button (visual)
+    mb = _round_view(card, NSMakeRect(w - PAD - 20, 12, 20, 20), _c("#3d3929", 0.0), 6)
+    _round_view(mb, NSMakeRect(5.5, 9.2, 9, 1.6), GREY2, 0.8)
+    # ---- usage rows ----
+    y = 46
+    for lab, pct, cd in (("5h", u.fh, u.fh_reset_s), ("7d", u.sd, u.sd_reset_s)):
+        _lbl(card, NSMakeRect(PAD, y, 26, 16), 12.5, NSFontWeightSemibold, GREY, lab)
+        bar = GradBar.alloc().initWithFrame_pct_(NSMakeRect(PAD + 30, y + 4, w - PAD * 2 - 30 - 44 - 52 - 20, 7), pct)
+        bar.setWantsLayer_(True); card.addSubview_(bar)
+        _lbl(card, NSMakeRect(w - PAD - 52 - 52, y, 44, 16), 13, NSFontWeightBold, INK,
+             ("–" if pct is None else f"{pct}%"), right=True)
+        _lbl(card, NSMakeRect(w - PAD - 52, y, 52, 16), 11.5, NSFontWeightRegular, GREY2,
+             HD.fmt_dur(cd), right=True)
+        y += 28
+    # ---- divider ----
+    dv = NSView.alloc().initWithFrame_(NSMakeRect(0, HEADER_H - 1, w, 1))
+    dv.setWantsLayer_(True); dv.layer().setBackgroundColor_(DIVIDER.CGColor())
+    card.addSubview_(dv)
+    # ---- agentparty header ----
+    _lbl(card, NSMakeRect(PAD, HEADER_H + 12, 200, 14), 11, NSFontWeightSemibold, INK_Hdr, "AGENTPARTY")
+    # ---- scrollable list ----
+    chs = state["channels"]
+    if not chs:
+        _lbl(card, NSMakeRect(PAD, LIST_TOP + 6, w - 2 * PAD, 15), 12, NSFontWeightRegular, GREY2, "无活跃 channel")
+        return
+    state["scroll"] = max(0.0, min(state["scroll"], _max_scroll()))
+    clip = Flipped.alloc().initWithFrame_(NSMakeRect(0, LIST_TOP, w, LIST_H))
+    clip.setWantsLayer_(True); clip.layer().setMasksToBounds_(True)
+    card.addSubview_(clip)
+    total = len(chs) * AGENT_ROW_H
+    inner = Flipped.alloc().initWithFrame_(NSMakeRect(0, -state["scroll"], w, max(total, LIST_H)))
+    clip.addSubview_(inner)
+    for i, c in enumerate(chs):
+        yy = i * AGENT_ROW_H
+        state["rows"].append(c["key"])
+        if c["key"] == state["locked"]:
+            _round_view(inner, NSMakeRect(PAD - 8, yy + 3, w - 2 * (PAD - 8), AGENT_ROW_H - 6), HOVER, 8)
+        _dot(inner, NSMakeRect(PAD, yy + 11, 10, 10), dot_color(c["age_s"]))
+        name_w = w - PAD - 18 - PAD - 40
+        _lbl(inner, NSMakeRect(PAD + 20, yy + 6, name_w, 18), 13.5, NSFontWeightSemibold, INK, c["channel"])
+        if c["unread"]:
+            bw = 20 + len(str(c["unread"])) * 7
+            badge = _round_view(inner, NSMakeRect(w - PAD - bw, yy + 7, bw, 16), ORANGE, 8)
+            _lbl(badge, NSMakeRect(0, 0, bw, 16), 10.5, NSFontWeightBold, BG, str(c["unread"]), center=True)
+        prev = (c["last_preview"] or "").replace("\n", " ")
+        if c["last_from"] or prev:
+            m = NSMutableAttributedString.alloc().initWithString_(f"{c['last_from']}: {prev}")
+            fs = full = m.string()
+            fr = fs.rangeOfString_(f"{c['last_from']}:")
+            fnt = NSFont.systemFontOfSize_weight_(12, NSFontWeightRegular)
+            m.addAttribute_value_range_(NSFontAttributeName, fnt, (0, len(fs)))
+            m.addAttribute_value_range_(NSForegroundColorAttributeName, GREY, (0, len(fs)))
+            if fr.length:
+                m.addAttribute_value_range_(NSForegroundColorAttributeName, GREY2, fr)
+            pl = _lbl(inner, NSMakeRect(PAD + 20, yy + 24, w - PAD - 20 - PAD, 15), 12, NSFontWeightRegular, GREY, "")
+            pl.setAttributedStringValue_(m)
+    if _max_scroll() > 0:
+        frac = LIST_H / max(total, LIST_H)
+        th = max(24, LIST_H * frac)
+        ty = LIST_TOP + (LIST_H - th) * (state["scroll"] / _max_scroll())
+        sb = _round_view(card, NSMakeRect(w - 5, ty, 3, th), _c("#3d3929", 0.16), 1.5)
+
+
+# ---------------- interaction ----------------
+class HUDView(objc.lookUpClass("NSView")):
+    def initWithFrame_ctrl_(self, frame, ctrl):
+        self = objc.super(HUDView, self).initWithFrame_(frame)
+        if self is None: return None
+        self.ctrl, self._down, self._moved = ctrl, None, False
+        return self
+
+    def mouseDown_(self, ev):
+        self._down = NSEvent.mouseLocation(); self._moved = False
+
+    def mouseDragged_(self, ev):
+        if self._down is None: return
+        loc = NSEvent.mouseLocation()
+        dx, dy = loc.x - self._down.x, loc.y - self._down.y
+        if abs(dx) + abs(dy) > 3: self._moved = True
+        win = self.window()
+        o = win.frame().origin
+        np = NSMakePoint(o.x + dx, o.y + dy)
+        win.setFrameOrigin_(np)
+        state["abs"] = [float(np.x), float(np.y)]     # lock to absolute screen pos
+        self._down = loc
+
+    def scrollWheel_(self, ev):
+        if not state["expanded"]: return
+        state["scroll"] = max(0.0, min(_max_scroll(), state["scroll"] - ev.deltaY() * 6))
+        self.ctrl.relayout()
+
+    def mouseUp_(self, ev):
+        if self._moved:
+            self._down = None; save_persist(); return
+        if state["expanded"]:
+            loc = ev.locationInWindow()
+            h = self.frame().size.height
+            # card is inset by SH; convert to card-flipped coords
+            fy = (h - loc.y) - SH
+            if LIST_TOP <= fy <= LIST_TOP + LIST_H:
+                idx = int((fy - LIST_TOP + state["scroll"]) / AGENT_ROW_H)
+                if 0 <= idx < len(state["rows"]):
+                    key = state["rows"][idx]
+                    state["locked"] = None if state["locked"] == key else key
+                    self.ctrl.relayout(); self._down = None; save_persist(); return
+            state["expanded"] = False
+        else:
+            state["expanded"] = True
+        self.ctrl.relayout(); self._down = None; save_persist()
+
+
+class Ctrl(objc.lookUpClass("NSObject")):
+    def initWithPanel_card_(self, panel, card):
+        self = objc.super(Ctrl, self).init()
+        if self is None: return None
+        self.panel, self.card, self.t0, self._sig = panel, card, time.time(), None
+        self._miss = 0
+        self._placed = False
+        return self
+
+    def _content_size(self):
+        return (EXP_W, EXP_H) if state["expanded"] else (COLLAPSED_W, COLLAPSED_H)
+
+    def _panel_size(self):
+        cw, ch = self._content_size()
+        return (cw + 2 * SH, ch + 2 * SH)
+
+    def _origin(self):
+        if state.get("abs"):                          # user placed it -> fixed
+            return NSMakePoint(state["abs"][0], state["abs"][1])
+        b = claude_bounds(); pw, ph = self._panel_size()
+        if b:
+            _, x, y, cw, ch = b
+            sh = NSScreen.screens()[0].frame().size.height
+            ox = (x + cw) - pw + SH - MARGIN
+            oy = (sh - (y + ch)) - SH + MARGIN
+        else:
+            f = NSScreen.screens()[0].frame()
+            ox = f.size.width - pw - MARGIN; oy = MARGIN
+        return NSMakePoint(ox, oy)
+
+    def reposition(self):
+        self.panel.setFrameOrigin_(self._origin())
+
+    def relayout(self):
+        cw, ch = self._content_size()
+        pw, ph = self._panel_size()
+        cur = self.panel.frame().origin
+        if not self._placed:                 # first layout: use default/persisted spot
+            o = self._origin(); cur = NSMakePoint(o.x, o.y); self._placed = True
+        # keep current position (user-placed); only size/content change
+        self.panel.setFrame_display_animate_(NSMakeRect(cur.x, cur.y, pw, ph), True, False)
+        self.card.setFrame_(NSMakeRect(SH, SH, cw, ch))
+        self.card.layer().setCornerRadius_(ch / 2 if not state["expanded"] else 14.0)
+        build_content(self.card)
+
+    def tick_(self, timer):
+        if DURATION and time.time() - self.t0 > DURATION:
+            NSApp().terminate_(None); return
+        if claude_bounds() is None:                 # tolerate transient misses
+            self._miss += 1
+            if self._miss > 15 and self.panel.isVisible():   # ~1.5s truly gone
+                self.panel.orderOut_(None)
+            return
+        self._miss = 0
+        if not self.panel.isVisible():
+            self.panel.orderFrontRegardless()
+        refresh_data()
+        sig = (state["u"].fh, state["u"].sd, state["expanded"], state["locked"],
+               round(state["scroll"]), tuple((c["key"], c["unread"]) for c in state["channels"]))
+        if sig != self._sig:
+            self._sig = sig
+            self.relayout()
+        # NOTE: never reposition on tick — position is owned solely by the user's
+        # drag (mouseDragged). Touching it every frame fought macOS at screen
+        # edges and caused jitter.
+
+
+def claude_bounds():
+    opts = Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements
+    best = None
+    for w in Quartz.CGWindowListCopyWindowInfo(opts, Quartz.kCGNullWindowID):
+        if "Claude" not in (w.get("kCGWindowOwnerName") or "") or w.get("kCGWindowLayer") != 0:
+            continue
+        b = w.get("kCGWindowBounds"); area = b["Width"] * b["Height"]
+        if best is None or area > best[0]:
+            best = (area, b["X"], b["Y"], b["Width"], b["Height"])
+    return best
+
+
+def _acquire_single_instance():
+    try:
+        old = int(HUD_PID_PATH.read_text())
+    except (FileNotFoundError, ValueError):
+        old = None
+    if old and old != os.getpid():
+        try:
+            os.kill(old, 0)
+            return False              # another live instance
+        except ProcessLookupError:
+            pass                      # stale pid -> take over
+        except PermissionError:
+            return False
+    try:
+        HUD_PID_PATH.write_text(str(os.getpid()))
+    except Exception:
+        pass
+    return True
+
+
+def run(argv=None):
+    if not _acquire_single_instance():
+        print("[hud] 已有实例在运行,退出", file=sys.stderr)
+        return
+    load_persist()
+    app = NSApplication.sharedApplication()
+    app.setActivationPolicy_(NSApplicationActivationPolicyAccessory)
+    refresh_data(force=True)
+    print("[hud] 5h/7d:", state["u"].fh, state["u"].sd, "| channels:", len(state["channels"]))
+
+    pw, ph = (EXP_W + 2 * SH, EXP_H + 2 * SH)
+    panel = FreePanel.alloc().initWithContentRect_styleMask_backing_defer_(
+        NSMakeRect(0, 0, pw, ph),
+        NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel,
+        NSBackingStoreBuffered, False)
+    panel.setOpaque_(False); panel.setBackgroundColor_(NSColor.clearColor())
+    panel.setLevel_(NSStatusWindowLevel); panel.setIgnoresMouseEvents_(False)
+    panel.setBecomesKeyOnlyIfNeeded_(True); panel.setHidesOnDeactivate_(False)
+    panel.setHasShadow_(False)
+    panel.setCollectionBehavior_(
+        NSWindowCollectionBehaviorCanJoinAllSpaces
+        | NSWindowCollectionBehaviorStationary
+        | NSWindowCollectionBehaviorFullScreenAuxiliary)
+
+    hv = HUDView.alloc().initWithFrame_ctrl_(NSMakeRect(0, 0, pw, ph), None)
+    # card with warm bg, rounded corners, soft warm shadow (masksToBounds False so shadow shows)
+    card = Flipped.alloc().initWithFrame_(NSMakeRect(SH, SH, EXP_W, EXP_H))
+    card.setWantsLayer_(True)
+    lyr = card.layer()
+    lyr.setBackgroundColor_(BG.CGColor())
+    lyr.setCornerRadius_(14.0)
+    lyr.setBorderWidth_(1.0)
+    lyr.setBorderColor_(BORDER.CGColor())
+    lyr.setShadowColor_(_c("#3d3929").CGColor())
+    lyr.setShadowOpacity_(0.18)
+    lyr.setShadowRadius_(16.0)
+    lyr.setShadowOffset_((0, -5))
+    hv.addSubview_(card)
+    panel.setContentView_(hv)
+
+    ctrl = Ctrl.alloc().initWithPanel_card_(panel, card); hv.ctrl = ctrl
+    ctrl.relayout(); panel.orderFrontRegardless()
+    NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+        0.1, ctrl, "tick:", None, True)
+    print("[hud] running — Claude 面板样式")
+    app.run()
+
+
+if __name__ == "__main__":
+    run(sys.argv[1:])

--- a/src/claude_statusbar/hud_data.py
+++ b/src/claude_statusbar/hud_data.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""P0 data layer for the desktop HUD.
+
+- Official 5h/7d used% + reset countdowns from Claude Desktop's own
+  plan-usage-history.json (sampled every 5 min; instant read).
+- AgentParty status for the *current active session's project*, located by the
+  most-recently-touched transcript, via the project's own party module.
+"""
+import json, time, sys, glob, os
+from pathlib import Path
+from dataclasses import dataclass
+from typing import Optional, List, Dict, Any
+
+PLAN_USAGE = Path.home() / "Library/Application Support/Claude/plan-usage-history.json"
+PROJECTS = Path.home() / ".claude/projects"
+FIVE_H = 5 * 3600
+SEVEN_D = 7 * 24 * 3600
+DROP = 15
+STALE_S = 15 * 60
+SESSION_ACTIVE_S = 600      # transcript touched within 10 min => "current session"
+
+try:
+    from .party import read_party_status  # same package
+    _PARTY_OK = True
+except Exception:
+    _PARTY_OK = False
+
+
+@dataclass
+class Usage:
+    fh: Optional[int] = None
+    sd: Optional[int] = None
+    org: str = ""
+    sample_age_s: Optional[float] = None
+    fh_reset_s: Optional[float] = None
+    sd_reset_s: Optional[float] = None
+    stale: bool = False
+    err: str = ""
+    # party
+    project: str = ""
+    party: Optional[Dict[str, Any]] = None    # None => no party in this project
+
+
+# ---------- usage ----------
+def _load_usage() -> List[Dict]:
+    d = json.loads(PLAN_USAGE.read_text(encoding="utf-8"))
+    return d.get("samples", [])
+
+
+def _last_reset_ms(samples, key):
+    last = None
+    for i in range(1, len(samples)):
+        a, b = samples[i - 1]["u"].get(key), samples[i]["u"].get(key)
+        if a is None or b is None:
+            continue
+        if a - b >= DROP:
+            last = samples[i]["t"]
+    return last
+
+
+def _countdown(samples, key, window_s, now):
+    lr = _last_reset_ms(samples, key)
+    if lr is None:
+        return None
+    r = lr / 1000 + window_s - now
+    while r < 0:
+        r += window_s
+    return r
+
+
+# ---------- party (current session's project) ----------
+def _cwd_of(transcript: Path) -> Optional[str]:
+    try:
+        with open(transcript, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                if '"cwd"' not in line:
+                    continue
+                o = json.loads(line)
+                if o.get("cwd"):
+                    return o["cwd"]
+    except Exception:
+        pass
+    return None
+
+
+def _active_session():
+    """(transcript_path, cwd) of the most-recently-touched transcript, or None."""
+    try:
+        jsonls = sorted(PROJECTS.glob("*/*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True)
+    except Exception:
+        return None
+    if not jsonls:
+        return None
+    top = jsonls[0]
+    if time.time() - top.stat().st_mtime > SESSION_ACTIVE_S:
+        return None
+    return top, _cwd_of(top)
+
+
+def _party_for_project(now):
+    if not _PARTY_OK:
+        return "", None
+    act = _active_session()
+    if not act:
+        return "", None
+    top, cwd = act
+    if not cwd:
+        return "", None
+    project = Path(cwd).name
+    try:
+        ps = read_party_status(cwd, now=now)
+    except Exception:
+        return project, None
+    if ps is None:
+        return project, None
+    return project, {
+        "channel": ps.channel,
+        "identity": ps.identity_name,
+        "unread": ps.unread,
+        "last_from": ps.last_from,
+        "last_preview": ps.last_preview,
+        "last_age": ps.last_age,
+        "live": ps.listener_alive and not ps.listener_stale,
+        "present": ps.listener_present,
+        "stale": ps.listener_stale,
+        "mentioned": ps.mentioned,
+        "fresh": ps.fresh,
+    }
+
+
+AGENTPARTY_STATE = Path.home() / ".agentparty/state"
+CHANNEL_ACTIVE_S = 1800   # only channels touched within 30 min count as "active"
+
+
+def all_channels(top_n: int = 3, max_age_s: int = CHANNEL_ACTIVE_S,
+                 now: Optional[float] = None) -> List[Dict[str, Any]]:
+    """All currently-active AgentParty channels, deduped by channel, ranked by
+    unread-first then recency. Scans every workspace's statusline.json."""
+    now = time.time() if now is None else now
+    best: Dict[str, Dict[str, Any]] = {}
+    try:
+        files = AGENTPARTY_STATE.glob("*/statusline.json")
+    except Exception:
+        return []
+    for f in files:
+        try:
+            d = json.loads(f.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        ch = d.get("channel")
+        ua = d.get("updated_at", 0) or 0
+        if not ch or (now - ua / 1000) > max_age_s:
+            continue
+        last = d.get("last_message") if isinstance(d.get("last_message"), dict) else {}
+        rec = {
+            "key": ch,
+            "channel": ch,
+            "identity": (d.get("identity") or {}).get("name", ""),
+            "unread": d.get("unread", 0) or 0,
+            "last_from": last.get("from", ""),
+            "last_preview": last.get("preview", ""),
+            "age_s": now - ua / 1000,
+            "updated": ua,
+        }
+        if ch not in best or ua > best[ch]["updated"]:
+            best[ch] = rec
+    chans = sorted(best.values(), key=lambda r: (0 if r["unread"] else 1, r["age_s"]))
+    return chans[:top_n]
+
+
+def snapshot(org: Optional[str] = None, now: Optional[float] = None) -> Usage:
+    now = time.time() if now is None else now
+    try:
+        alls = _load_usage()
+    except FileNotFoundError:
+        u = Usage(err="plan-usage-history.json 不存在")
+        u.project, u.party = _party_for_project(now)
+        return u
+    except Exception as e:
+        return Usage(err=f"读取失败: {e}")
+    if not alls:
+        return Usage(err="无样本")
+    cur_org = org or alls[-1].get("org", "")
+    s = [e for e in alls if e.get("org") == cur_org]
+    last = s[-1]
+    age = now - last["t"] / 1000
+    u = Usage(
+        fh=last["u"].get("fh"), sd=last["u"].get("sd"), org=cur_org,
+        sample_age_s=age,
+        fh_reset_s=_countdown(s, "fh", FIVE_H, now),
+        sd_reset_s=_countdown(s, "sd", SEVEN_D, now),
+        stale=age > STALE_S,
+    )
+    u.project, u.party = _party_for_project(now)
+    return u
+
+
+def fmt_dur(s):
+    if s is None:
+        return "—"
+    s = int(s)
+    h, m = s // 3600, (s % 3600) // 60
+    if h >= 24:
+        return f"{h//24}d{h%24}h"
+    return f"{h}h{m:02d}m" if h else f"{m}m"
+
+
+if __name__ == "__main__":
+    u = snapshot()
+    print("err:", u.err or "(none)")
+    print(f"5h: {u.fh}%  reset {fmt_dur(u.fh_reset_s)}   |   7d: {u.sd}%  reset {fmt_dur(u.sd_reset_s)}")
+    print(f"project: {u.project}   party: {u.party}")


### PR DESCRIPTION
## 新功能：Claude 桌面客户端浮窗 HUD (`cs hud`)

在 Claude 桌面 app 右下角悬浮一个可拖动、点击展开的面板，显示官方 5h/7d 用量 + AgentParty 活跃 channel。桌面 app 没有 `statusLine` hook，所以用独立置顶窗口；数据来自桌面 app 自己每 5 分钟写的 `plan-usage-history.json`（官方精确值，非估算），不依赖 statusLine。

### 用法（macOS）
```bash
pip install 'claude-statusbar[hud]'
cs hud install   # launchd 常驻，开机自启 + 崩溃重启
```

### 包含
- **hud_data.py**：5h/7d 官方 used% + reset 倒计时 + party channel 聚合
- **hud.py**：pyobjc 浮窗，Claude 品牌样式（米白卡片/橙渐变条/彩色状态点）；拖动锁定绝对位置、滚轮翻列表、点行锁定 channel、Claude 关闭自动隐藏、单实例锁
- **cli.py**：`cs hud start/install/uninstall/stop`，launchd 单点管理
- **pyproject**：`[hud]` 可选依赖（pyobjc，仅 macOS）——**主体仍零依赖，不受影响**

### README
精简 Latest release（15→6 条）、cache countdown 伪代码（-38 行）、config 键表；新增 Desktop HUD 章节。净 -26 行。

仅 macOS；非 macOS `cs hud` 给友好提示。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a macOS Desktop HUD available through `cs hud`.
  * Displays 5-hour and 7-day usage, reset timers, active channels, unread indicators, and current session details.
  * Supports collapsed or expanded views, channel locking, scrolling, dragging, and saved positioning.
  * Added commands to start, install, stop, and uninstall the HUD.
  * HUD operates locally and hides when the desktop app is unavailable.

* **Documentation**
  * Added setup, command, behavior, and configuration guidance for the Desktop HUD.
  * Updated release notes and configuration references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->