### PR TITLE
feat(setup): treat `python -m claude_statusbar.cli` as our own statusLine

### DIFF
--- a/src/claude_statusbar/render_thin.py
+++ b/src/claude_statusbar/render_thin.py
@@ -167,7 +167,15 @@ def _displacement_suffix() -> str:
     cmd = sl.get("command")
     if not isinstance(cmd, str) or not cmd.strip():
         return ""
-    name = Path(cmd.strip().split()[0]).name
+    if "claude_statusbar" in cmd:
+        # `<python> -m claude_statusbar.cli render` — ours, just not via the
+        # console script. See setup._invokes_our_module.
+        return ""
+    name = Path(cmd.strip().split()[0]).name.lower()
+    for _ext in (".exe", ".cmd", ".bat"):
+        if name.endswith(_ext):
+            name = name[: -len(_ext)]
+            break
     if name in _OUR_BINARY_NAMES:
         return ""
     # ANSI red. Kept short so it doesn't blow up the bar on narrow terminals.

--- a/src/claude_statusbar/render_thin.py
+++ b/src/claude_statusbar/render_thin.py
@@ -171,7 +171,11 @@ def _displacement_suffix() -> str:
         # `<python> -m claude_statusbar.cli render` — ours, just not via the
         # console script. See setup._invokes_our_module.
         return ""
-    name = Path(cmd.strip().split()[0]).name.lower()
+    # Split on both separators rather than via Path: a `C:\...\cs.EXE` entry
+    # must still reduce to its basename when this code runs on POSIX (CI, and
+    # a settings.json synced off a Windows box), where PosixPath keeps the
+    # whole backslash string as one `.name`.
+    name = cmd.strip().split()[0].replace("\\", "/").rsplit("/", 1)[-1].lower()
     for _ext in (".exe", ".cmd", ".bat"):
         if name.endswith(_ext):
             name = name[: -len(_ext)]

--- a/src/claude_statusbar/setup.py
+++ b/src/claude_statusbar/setup.py
@@ -110,6 +110,18 @@ def _statusline_config(fast: bool = False, refresh_interval: int = DEFAULT_REFRE
     }
 
 
+def _invokes_our_module(cmd: str) -> bool:
+    """True for ``<python> -m claude_statusbar.cli render``.
+
+    A legitimate way to run us that skips pip's console-script launcher. On
+    Windows that launcher spawns a second process, roughly doubling status-line
+    latency (~0.9s vs ~0.44s per render on a conda install), so users on slow
+    Python startups may prefer the module form. Recognise it as ours rather
+    than reporting it as a foreign tool.
+    """
+    return "claude_statusbar" in cmd
+
+
 def _is_our_statusline(entry: object) -> bool:
     """Return True if the existing statusLine entry already points at our CLI."""
     if not isinstance(entry, dict):
@@ -117,6 +129,8 @@ def _is_our_statusline(entry: object) -> bool:
     cmd = entry.get("command")
     if not isinstance(cmd, str) or not cmd.strip():
         return False
+    if _invokes_our_module(cmd):
+        return True
     name = _normalize_command_name(Path(cmd.strip().split()[0]).name)  # strip args + path + .exe shim
     return name in OUR_COMMAND_NAMES
 
@@ -158,7 +172,9 @@ def _existing_uses_render(existing) -> bool:
     if not isinstance(cmd, str):
         return False
     parts = cmd.strip().split()
-    return len(parts) >= 2 and parts[1] == "render"
+    # `cs render`, and the module form `<python> -m claude_statusbar.cli render`
+    # — in both, `render` is the last token.
+    return len(parts) >= 2 and parts[-1] == "render"
 
 
 def ensure_statusline_configured(fast: Optional[bool] = None) -> Tuple[bool, str]:
@@ -217,6 +233,13 @@ def ensure_statusline_configured(fast: Optional[bool] = None) -> Tuple[bool, str
     else:
         effective_refresh = DEFAULT_REFRESH_INTERVAL
     desired = _statusline_config(fast=effective_fast, refresh_interval=effective_refresh)
+
+    # The module form is a deliberate choice (see `_invokes_our_module`), not
+    # drift — the daily repair pass must not rewrite it back to the console
+    # script. Keep the command, still refresh refreshInterval.
+    existing_cmd = existing.get("command")
+    if isinstance(existing_cmd, str) and _invokes_our_module(existing_cmd):
+        desired["command"] = existing_cmd
 
     if (existing.get("command") != desired["command"]
             or existing.get("refreshInterval") != desired["refreshInterval"]):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1098,3 +1098,67 @@ def test_windows_identity_false_when_no_shell_available(monkeypatch):
     )
 
     assert _d._process_is_our_daemon(4242) is False
+
+
+MODULE_STATUSLINE = "C:/Users/x/miniconda3/python.exe -m claude_statusbar.cli render"
+
+
+def test_module_invocation_counts_as_ours():
+    """`<python> -m claude_statusbar.cli render` skips pip's console-script
+    launcher, which on Windows spawns a second process and roughly doubles
+    per-render latency. It must not be mistaken for a foreign tool."""
+    assert _is_our_statusline({"type": "command", "command": MODULE_STATUSLINE}) is True
+
+    from claude_statusbar.setup import _existing_uses_render
+    assert _existing_uses_render({"command": MODULE_STATUSLINE}) is True
+
+
+def test_daily_repair_does_not_rewrite_module_invocation(monkeypatch, tmp_path):
+    """The once-a-day auto-repair pass would otherwise replace a deliberate
+    module invocation with the console script every single day."""
+    from claude_statusbar import setup as _setup
+
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({
+        "statusLine": {"type": "command", "command": MODULE_STATUSLINE,
+                       "refreshInterval": 1},
+    }), encoding="utf-8")
+    monkeypatch.setattr(_setup, "SETTINGS_PATH", settings)
+
+    changed, msg = _setup.ensure_statusline_configured()
+
+    assert changed is False, msg
+    after = json.loads(settings.read_text(encoding="utf-8"))
+    assert after["statusLine"]["command"] == MODULE_STATUSLINE
+
+
+def test_displacement_warning_silent_for_module_invocation(monkeypatch, tmp_path):
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({
+        "statusLine": {"type": "command", "command": MODULE_STATUSLINE},
+    }), encoding="utf-8")
+    monkeypatch.setattr(render_thin, "_USER_SETTINGS", settings)
+
+    assert render_thin._displacement_suffix() == ""
+
+
+def test_displacement_warning_silent_for_windows_exe_shim(monkeypatch, tmp_path):
+    """pip writes `cs.EXE` on Windows; case + extension must not read as foreign."""
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({
+        "statusLine": {"type": "command",
+                       "command": r"C:\Users\x\Scripts\cs.EXE render"},
+    }), encoding="utf-8")
+    monkeypatch.setattr(render_thin, "_USER_SETTINGS", settings)
+
+    assert render_thin._displacement_suffix() == ""
+
+
+def test_displacement_warning_still_fires_for_foreign_tool(monkeypatch, tmp_path):
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({
+        "statusLine": {"type": "command", "command": "starship prompt"},
+    }), encoding="utf-8")
+    monkeypatch.setattr(render_thin, "_USER_SETTINGS", settings)
+
+    assert "starship" in render_thin._displacement_suffix()


### PR DESCRIPTION
### Why

pip's console-script launcher spawns a second process on Windows, which
roughly doubles per-render latency. Measured on a conda install, same payload,
6 runs each:

| invocation | median |
|---|---|
| `python -m claude_statusbar.cli render` | 0.44s |
| `cs.exe render` | 0.92s |
| `python -c pass` (interpreter floor) | 0.41s |

Nearly all of the console script's cost is the extra process — the module form
is within 30ms of the interpreter floor. On a machine where Claude Code kills
a slow statusLine, halving that matters.

### Problem

The module form is a perfectly valid way to run us, but nothing recognised it:

- `_displacement_suffix()` painted a red `⚠ statusLine 被 python.exe 占用`
  warning onto the bar on **every render**.
- `cs doctor` reported `(not ours)`.
- the daily `ensure_statusline_configured()` repair pass rewrote it back to
  the console script, so the choice would not survive a day.

### Fix

- `_is_our_statusline()` / `_displacement_suffix()`: a command containing
  `claude_statusbar` is ours.
- `ensure_statusline_configured()`: keep an existing module invocation instead
  of overwriting it (refreshInterval is still refreshed).
- `_existing_uses_render()`: match `render` as the **last** token, so fast mode
  is detected for both `cs render` and the module form.
- `_displacement_suffix()` also gained the lowercase + `.exe/.cmd/.bat`
  normalisation `_is_our_statusline()` already had — a `cs.EXE render` entry
  was painting the same false warning (the tail of #32).

### Tests

Five cases in `tests/test_daemon.py`: module form is ours and reads as fast
mode; the daily repair leaves it untouched; no displacement warning for the
module form or for `cs.EXE render`; a genuinely foreign command
(`starship prompt`) still warns.

`tests/test_daemon.py` + `tests/test_setup.py`: 93 passed, 1 skipped, 4
pre-existing unrelated failures on this Windows checkout, unchanged by the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved module-based `statusLine` commands during configuration refreshes to avoid unwanted rewrites.
  * Improved detection to suppress displacement warnings for module invocations and Windows shim paths.
  * Enhanced command parsing by normalizing extracted executable names and supported extensions.
  * Continued to warn when a genuinely different `statusLine` command is configured.
* **Tests**
  * Added coverage for module-based commands, Windows shims, configuration preservation, and foreign status-line detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->