### PR TITLE
fix(test): 消掉 Windows cmdline 用例里的 SyntaxWarning

### DIFF
--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1062,7 +1062,7 @@ def test_windows_identity_uses_cim_not_ps(monkeypatch):
             raise AssertionError("ps must not be consulted on win32")
         return _sp.CompletedProcess(
             cmd, 0,
-            stdout=('"C:\Python\python.exe" -m claude_statusbar.cli '
+            stdout=(r'"C:\Python\python.exe" -m claude_statusbar.cli '
                     'daemon _run --render-interval 1.0\n'),
             stderr="",
         )
@@ -1081,7 +1081,7 @@ def test_windows_identity_false_when_pid_is_someone_else(monkeypatch):
     monkeypatch.setattr(
         _sp, "run",
         lambda cmd, **kw: _sp.CompletedProcess(
-            cmd, 0, stdout="C:\Windows\explorer.exe\n", stderr=""),
+            cmd, 0, stdout="C:\\Windows\\explorer.exe\n", stderr=""),
     )
 
     assert _d._process_is_our_daemon(4242) is False


### PR DESCRIPTION
#38 合入时带进来的两条断言用了非法转义序列：

- `"C:\Python\python.exe"` → `\P`
- `"C:\Windows\explorer.exe"` → `\W`

Python 3.12+ 每次收集测试都会打 SyntaxWarning，未来版本里会直接变 SyntaxError。改成 raw string / 显式转义，断言内容和覆盖不变。

验证：`compile()` 扫全量 src+tests，syntax warnings 从 2 降到 0；`tests/test_daemon.py` 65 passed。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Windows daemon-identity test fixtures to accurately reflect expected command output.
  * Corrected escaping in mocked process results to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->