### PR TITLE
fix(core): trust-tier context tokens — cross-check totals against pct instead of version-gating

### DIFF
--- a/src/claude_statusbar/core.py
+++ b/src/claude_statusbar/core.py
@@ -198,8 +198,14 @@ def parse_stdin_data() -> Dict[str, Any]:
             result['context_used_pct'] = cw.get('used_percentage', 0)
             result['context_remaining_pct'] = cw.get('remaining_percentage', 100)
             result['context_window_size'] = cw.get('context_window_size', 0)
-            result['total_input_tokens'] = cw.get('total_input_tokens', 0)
-            result['total_output_tokens'] = cw.get('total_output_tokens', 0)
+            if 'total_input_tokens' in cw:
+                result['total_input_tokens'] = cw.get('total_input_tokens')
+            if 'total_output_tokens' in cw:
+                result['total_output_tokens'] = cw.get('total_output_tokens')
+            # Preserve absent vs explicit null: current_usage is authoritative
+            # when present, while null is a lifecycle sentinel after /compact.
+            if 'current_usage' in cw:
+                result['context_current_usage'] = cw.get('current_usage')
 
         # Session cost
         cost = data.get('cost', {})
@@ -255,14 +261,18 @@ def _leading_int(token: str) -> int:
     return int(digits) if digits else 0
 
 
-def _claude_emits_rate_limits(version) -> bool:
-    """True when `version` (Claude Code's reported version) is new enough to emit
-    official rate_limits. Tolerates suffixes ('2.1.80-beta') and junk (→ False)."""
+def _claude_version_at_least(version, minimum) -> bool:
+    """Compare Claude Code versions while tolerating suffixes and junk."""
     if not version:
         return False
     parts = tuple(_leading_int(p) for p in str(version).split(".")[:3])
     parts = parts + (0,) * (3 - len(parts))
-    return parts >= _RATE_LIMITS_MIN_VERSION
+    return parts >= minimum
+
+
+def _claude_emits_rate_limits(version) -> bool:
+    """True when Claude Code is new enough to emit official rate_limits."""
+    return _claude_version_at_least(version, _RATE_LIMITS_MIN_VERSION)
 
 
 def is_no_quota_mode(env: Dict[str, str], *, override: str = "auto") -> bool:
@@ -727,24 +737,65 @@ def _env_context_window_override(reported_size: float, env=None) -> Optional[int
     return None
 
 
-def _exact_used_tokens(stdin_data: Dict[str, Any]) -> Optional[int]:
-    """Context tokens as Claude Code reported them, or None when unavailable.
+def _token_count(value) -> Optional[int]:
+    """A nonnegative integer token count, rejecting bools/floats/strings."""
+    if type(value) is not int or value < 0:
+        return None
+    return value
 
-    None means "no usable signal" — an older Claude Code that omits the
-    totals, a relay payload that zeroes them, or a malformed value. Callers
-    fall back to deriving the count from the percentage.
+
+def _exact_used_tokens(stdin_data: Dict[str, Any]) -> Optional[int]:
+    """Authoritative input-side context tokens from current_usage, or None.
+
+    None is "no authoritative signal", never zero: the key may be absent
+    (fresh tick, old Claude Code), an explicit null (lifecycle sentinel
+    right after /compact), or malformed. Callers fall back to the
+    cross-checked totals, then to the reported percentage.
     """
+    if 'context_current_usage' not in stdin_data:
+        return None
+    current = stdin_data.get('context_current_usage')
+    if current is None or not isinstance(current, dict):
+        return None
     total = 0
-    for key in ('total_input_tokens', 'total_output_tokens'):
-        try:
-            total += int(stdin_data.get(key, 0) or 0)
-        except (TypeError, ValueError):
+    for key in ('input_tokens', 'cache_creation_input_tokens',
+                'cache_read_input_tokens'):
+        raw = current.get(key, 0)
+        count = _token_count(raw)
+        if count is None:
             return None
-    return total or None
+        total += count
+    return total
+
+
+# used_percentage is an integer percentage, so an honest totals reading can
+# sit up to ~1% off it; a little slack on top covers the two fields being
+# captured a tick apart. Anything further out means totals do not describe
+# the current context at all.
+_TOTALS_PCT_TOLERANCE = 1.5
+
+
+def _cross_checked_totals(stdin_data: Dict[str, Any], size: float,
+                          pct: Optional[float]) -> Optional[int]:
+    """total_input_tokens, but only when it agrees with used_percentage.
+
+    Totals silently change meaning across Claude Code versions and lifecycle
+    ticks — 2.1.220 still sends the cumulative session counter (tens of
+    millions on a long session) on the first ticks of a resume, before
+    current_usage appears. A version gate can't track that, so totals are
+    believed only when consistent with the percentage Claude Code itself
+    displays; otherwise the caller derives tokens from that percentage.
+    """
+    total = _token_count(stdin_data.get('total_input_tokens'))
+    if total is None or pct is None:
+        return None
+    if abs(total / size * 100.0 - pct) <= _TOTALS_PCT_TOLERANCE:
+        return total
+    return None
 
 
 def _context_window_usage(stdin_data: Dict[str, Any],
-                          env=None) -> Tuple[Optional[float], int, int]:
+                          env=None) -> Tuple[Optional[float], int, Optional[int]]:
     """Return (ctx_pct, ctx_size, ctx_used) for renderer/model suffix.
 
     Claude sometimes sends null for context_window.used_percentage. Treat that
@@ -774,22 +825,31 @@ def _context_window_usage(stdin_data: Dict[str, Any],
     # 10k on a 1M-context one, where the bar steps 60.0k → 70.0k and can sit
     # ~10k off the truth. `ctx_pct` itself stays as reported so the percentage
     # and its severity colour keep matching what Claude Code shows.
+    #
+    # Trust order: current_usage (authoritative, may honestly exceed the
+    # window while a compact is pending) → totals cross-checked against the
+    # percentage → the percentage itself → None ("unknown", renders as no
+    # suffix rather than a made-up 0).
     ctx_used = _exact_used_tokens(stdin_data)
     if ctx_used is None:
-        ctx_used = int(ctx_size_f * ctx_pct / 100) if ctx_pct is not None else 0
+        ctx_used = _cross_checked_totals(stdin_data, ctx_size_f, ctx_pct)
+    if ctx_used is None:
+        ctx_used = int(ctx_size_f * ctx_pct / 100) if ctx_pct is not None else None
 
     # Env override (#29): used tokens stay what stdin reported; the window and
     # the percentage are re-derived against the real (env-forced) size.
     override = _env_context_window_override(ctx_size_f, env)
     if override is not None and override != int(ctx_size_f):
-        if ctx_pct is not None:
+        if ctx_pct is not None and ctx_used is not None:
             ctx_pct = ctx_used / override * 100.0
         ctx_size_f = float(override)
-    return ctx_pct, int(ctx_size_f), int(ctx_used)
+    return ctx_pct, int(ctx_size_f), (int(ctx_used) if ctx_used is not None else None)
 
 
 def format_number(num: float) -> str:
     """Format number for detail display."""
+    if num >= 1_000_000_000:
+        return f"{num/1_000_000_000:.1f}B"
     if num >= 1_000_000:
         return f"{num/1_000_000:.1f}M"
     elif num >= 1_000:
@@ -1402,7 +1462,10 @@ def main(json_output: bool = False,
                     # Strip redundant size suffix like "(1M context)" from display_name
                     import re as _re
                     model = _re.sub(r'\s*\([^)]*context[^)]*\)', '', model)
-                    model = f"{model}({format_number(ctx_used)}/{format_number(ctx_size)})"
+                    # Unknown usage (fresh tick / post-compact sentinel) shows
+                    # a bare model name — no suffix beats a made-up "(0/1.0M)".
+                    if ctx_used is not None:
+                        model = f"{model}({format_number(ctx_used)}/{format_number(ctx_size)})"
 
                 countdown = get_countdown_emoji(minutes_to_reset)
 
@@ -1487,7 +1550,8 @@ def main(json_output: bool = False,
                 if ctx_size > 0:
                     import re as _re
                     model = _re.sub(r'\s*\([^)]*context[^)]*\)', '', model)
-                    model = f"{model}({format_number(ctx_used)}/{format_number(ctx_size)})"
+                    if ctx_used is not None:
+                        model = f"{model}({format_number(ctx_used)}/{format_number(ctx_size)})"
 
                 if json_output:
                     print(json.dumps({

--- a/tests/test_core_ctx_pct.py
+++ b/tests/test_core_ctx_pct.py
@@ -160,6 +160,24 @@ def test_totals_consistent_with_pct_are_trusted_exactly():
     assert ctx_used == 63_824
 
 
+def test_totals_at_tolerance_boundary_are_trusted():
+    _, _, ctx_used = core._context_window_usage({
+        "context_window_size": 1_000_000,
+        "context_used_pct": 6,
+        "total_input_tokens": 75_000,
+    })
+    assert ctx_used == 75_000
+
+
+def test_totals_past_tolerance_boundary_fall_back_to_pct():
+    _, _, ctx_used = core._context_window_usage({
+        "context_window_size": 1_000_000,
+        "context_used_pct": 6,
+        "total_input_tokens": 75_100,
+    })
+    assert ctx_used == 60_000
+
+
 @pytest.mark.parametrize("version", ["", "junk", "2.1.1"])
 def test_current_usage_wins_without_reliable_version(version):
     _, _, ctx_used = core._context_window_usage({

--- a/tests/test_core_ctx_pct.py
+++ b/tests/test_core_ctx_pct.py
@@ -1,10 +1,10 @@
-"""Unit tests for the ctx_pct nullable-discriminator logic in core.py.
+"""Context-window usage parsing and occupancy semantics."""
 
-The discriminator runs against a flattened stdin_data dict produced by
-core.py:568-575 (which reads `data['context_window']['used_percentage']`
-and writes it as top-level `context_used_pct`). These tests feed the
-already-flattened shape directly.
-"""
+import io
+import json
+import sys
+
+import pytest
 
 from claude_statusbar import core
 
@@ -13,42 +13,199 @@ def _compute_ctx_pct(stdin_data):
     return core._context_window_usage(stdin_data)[0]
 
 
+def _parse(monkeypatch, payload):
+    fake = io.StringIO(json.dumps(payload))
+    fake.isatty = lambda: False
+    monkeypatch.setattr(sys, "stdin", fake)
+    return core.parse_stdin_data()
+
+
 def test_no_context_window_yields_none():
     """Missing context_window_size means context segment is not surfaced."""
     assert _compute_ctx_pct({}) is None
-    assert _compute_ctx_pct({"context_used_pct": 50}) is None  # size=0
-    assert _compute_ctx_pct({"context_window_size": 0, "context_used_pct": 50}) is None
+    assert _compute_ctx_pct({"context_used_pct": 50}) is None
+    assert _compute_ctx_pct({
+        "context_window_size": 0,
+        "context_used_pct": 50,
+    }) is None
 
 
 def test_zero_pct_context_renders_calm():
-    """Genuine 0% (early in session) returns 0.0, not None.
-    This is the falsy-0 trap from spec review."""
-    out = _compute_ctx_pct({"context_window_size": 1_000_000, "context_used_pct": 0})
+    """Genuine 0% (early in session) returns 0.0, not None."""
+    out = _compute_ctx_pct({
+        "context_window_size": 1_000_000,
+        "context_used_pct": 0,
+    })
     assert out == 0.0
     assert out is not None
 
 
 def test_normal_context_returns_float():
-    out = _compute_ctx_pct({"context_window_size": 1_000_000, "context_used_pct": 42})
+    out = _compute_ctx_pct({
+        "context_window_size": 1_000_000,
+        "context_used_pct": 42,
+    })
     assert out == 42.0
     assert isinstance(out, float)
 
 
-def test_used_tokens_come_from_exact_totals_not_rounded_pct():
-    """used_percentage is a whole number; on a 1M window that quantises the
-    token readout to 10k steps. The exact totals must win."""
+def test_parse_preserves_current_usage_and_version(monkeypatch):
+    current = {
+        "input_tokens": 40_000,
+        "cache_creation_input_tokens": 3_824,
+        "cache_read_input_tokens": 20_000,
+        "output_tokens": 9_999,
+    }
+    parsed = _parse(monkeypatch, {
+        "version": "2.1.220",
+        "context_window": {
+            "context_window_size": 1_000_000,
+            "used_percentage": 6,
+            "total_input_tokens": 999_999,
+            "total_output_tokens": 888_888,
+            "current_usage": current,
+        },
+    })
+
+    assert parsed["context_current_usage"] == current
+    assert parsed["claude_version"] == "2.1.220"
+
+
+def test_parse_preserves_current_usage_absent_vs_null(monkeypatch):
+    absent = _parse(monkeypatch, {
+        "context_window": {"context_window_size": 200_000},
+    })
+    explicit_null = _parse(monkeypatch, {
+        "context_window": {
+            "context_window_size": 200_000,
+            "current_usage": None,
+        },
+    })
+
+    assert "context_current_usage" not in absent
+    assert "context_current_usage" in explicit_null
+    assert explicit_null["context_current_usage"] is None
+
+
+def test_current_usage_input_and_cache_tokens_are_authoritative():
     ctx_pct, _, ctx_used = core._context_window_usage({
+        "claude_version": "2.1.220",
+        "context_window_size": 1_000_000,
+        "context_used_pct": 6,
+        "total_input_tokens": 999_999,
+        "total_output_tokens": 888_888,
+        "context_current_usage": {
+            "input_tokens": 40_000,
+            "cache_creation_input_tokens": 3_824,
+            "cache_read_input_tokens": 20_000,
+            "output_tokens": 9_999,
+        },
+    })
+
+    assert ctx_used == 63_824
+    assert ctx_pct == 6.0
+
+
+def test_current_usage_can_report_exact_zero():
+    _, _, ctx_used = core._context_window_usage({
+        "context_window_size": 200_000,
+        "context_used_pct": 7,
+        "context_current_usage": {
+            "input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        },
+    })
+    assert ctx_used == 0
+
+
+@pytest.mark.parametrize("version", ["2.1.131", "2.1.220", "", "junk"])
+def test_totals_disagreeing_with_pct_fall_back_to_pct(version):
+    """Cumulative-style totals are rejected on every version — the pct
+    cross-check, not a version gate, decides whether totals are trusted."""
+    _, _, ctx_used = core._context_window_usage({
+        "claude_version": version,
+        "context_window_size": 1_000_000,
+        "context_used_pct": 6,
+        "total_input_tokens": 1_500_000,
+        "total_output_tokens": 900_000,
+    })
+    assert ctx_used == 60_000
+
+
+def test_cumulative_session_totals_rejected_by_cross_check():
+    """Real repro (2026-07-31): resume tick on 2.1.220 sent the cumulative
+    session counter as total_input_tokens. 73.6M vs a 7% reading must render
+    as the pct-derived 70k, not as '73.6M/1.0M'."""
+    _, _, ctx_used = core._context_window_usage({
+        "claude_version": "2.1.220",
+        "context_window_size": 1_000_000,
+        "context_used_pct": 7,
+        "total_input_tokens": 73_623_000,
+        "total_output_tokens": 296,
+    })
+    assert ctx_used == 70_000
+
+
+def test_totals_consistent_with_pct_are_trusted_exactly():
+    """Within quantization tolerance of used_percentage, the exact totals
+    beat the 1%-quantized derivation. output tokens never count."""
+    _, _, ctx_used = core._context_window_usage({
+        "claude_version": "2.1.132",
         "context_window_size": 1_000_000,
         "context_used_pct": 6,
         "total_input_tokens": 63_824,
-        "total_output_tokens": 0,
+        "total_output_tokens": 999_999,
     })
-    assert ctx_used == 63_824  # not 60_000
-    assert ctx_pct == 6.0      # percentage stays as Claude Code reported it
+    assert ctx_used == 63_824
+
+
+@pytest.mark.parametrize("version", ["", "junk", "2.1.1"])
+def test_current_usage_wins_without_reliable_version(version):
+    _, _, ctx_used = core._context_window_usage({
+        "claude_version": version,
+        "context_window_size": 200_000,
+        "context_used_pct": 50,
+        "total_input_tokens": 190_000,
+        "context_current_usage": {
+            "input_tokens": 1_000,
+            "cache_creation_input_tokens": 200,
+            "cache_read_input_tokens": 300,
+            "output_tokens": 50_000,
+        },
+    })
+    assert ctx_used == 1_500
+
+
+@pytest.mark.parametrize("bad", [
+    {"input_tokens": "lots"},
+    {"input_tokens": -1},
+    {"input_tokens": True},
+    {"cache_read_input_tokens": 1.5},
+])
+def test_malformed_current_usage_falls_back_to_pct(bad):
+    _, _, ctx_used = core._context_window_usage({
+        "claude_version": "2.1.220",
+        "context_window_size": 200_000,
+        "context_used_pct": 25,
+        "total_input_tokens": 190_000,
+        "context_current_usage": bad,
+    })
+    assert ctx_used == 50_000
+
+
+def test_explicit_null_current_usage_falls_back_to_pct_after_compact():
+    _, _, ctx_used = core._context_window_usage({
+        "claude_version": "2.1.220",
+        "context_window_size": 1_000_000,
+        "context_used_pct": 12,
+        "total_input_tokens": 900_000,
+        "context_current_usage": None,
+    })
+    assert ctx_used == 120_000
 
 
 def test_used_tokens_fall_back_to_pct_when_totals_absent():
-    """Older Claude Code / relay payloads omit the totals entirely."""
     _, _, ctx_used = core._context_window_usage({
         "context_window_size": 200_000,
         "context_used_pct": 25,
@@ -56,8 +213,9 @@ def test_used_tokens_fall_back_to_pct_when_totals_absent():
     assert ctx_used == 50_000
 
 
-def test_malformed_totals_fall_back_to_pct():
+def test_malformed_total_falls_back_to_pct():
     _, _, ctx_used = core._context_window_usage({
+        "claude_version": "2.1.220",
         "context_window_size": 200_000,
         "context_used_pct": 25,
         "total_input_tokens": "lots",
@@ -65,13 +223,51 @@ def test_malformed_totals_fall_back_to_pct():
     assert ctx_used == 50_000
 
 
+def test_first_tick_everything_null_reports_unknown_not_zero():
+    """Session start/resume: null pct, null current_usage sentinel, totals
+    zeroed or cumulative — no trustworthy signal at all. ctx_used must be
+    None (renders as a bare model name), never a fabricated 0 or the
+    cumulative counter."""
+    ctx_pct, ctx_size, ctx_used = core._context_window_usage({
+        "claude_version": "2.1.220",
+        "context_window_size": 1_000_000,
+        "context_used_pct": None,
+        "context_current_usage": None,
+        "total_input_tokens": 73_623_000,
+    })
+    assert ctx_pct is None
+    assert ctx_size == 1_000_000
+    assert ctx_used is None
+
+
+def test_over_window_current_usage_is_kept_verbatim():
+    """current_usage may honestly exceed the window while a compact is
+    pending (seen live: 212k on a 200k window at 100%). Authoritative data
+    is not clamped."""
+    _, _, ctx_used = core._context_window_usage({
+        "claude_version": "2.1.220",
+        "context_window_size": 200_000,
+        "context_used_pct": 100,
+        "context_current_usage": {
+            "input_tokens": 2,
+            "cache_creation_input_tokens": 955,
+            "cache_read_input_tokens": 211_129,
+        },
+    })
+    assert ctx_used == 212_086
+
+
 def test_null_context_pct_is_unknown_not_error():
     ctx_pct, ctx_size, ctx_used = core._context_window_usage({
         "context_window_size": 1_000_000,
         "context_used_pct": None,
-        "total_input_tokens": 1200,
-        "total_output_tokens": 34,
+        "context_current_usage": {
+            "input_tokens": 1_000,
+            "cache_creation_input_tokens": 100,
+            "cache_read_input_tokens": 100,
+            "output_tokens": 99_999,
+        },
     })
     assert ctx_pct is None
     assert ctx_size == 1_000_000
-    assert ctx_used == 1234
+    assert ctx_used == 1_200

--- a/tests/test_ctx_env_override.py
+++ b/tests/test_ctx_env_override.py
@@ -80,15 +80,36 @@ def test_no_stdin_context_stays_hidden_even_with_env():
         == (None, 0, 0)
 
 
-def test_null_pct_keeps_token_fallback_and_overridden_size():
+def test_null_pct_keeps_exact_input_usage_and_overridden_size():
     ctx_pct, ctx_size, ctx_used = _usage(
-        {"context_window_size": 200_000, "context_used_pct": None,
-         "total_input_tokens": 1200, "total_output_tokens": 34},
+        {"context_window_size": 1_000_000, "context_used_pct": None,
+         "context_current_usage": {
+             "input_tokens": 40_000,
+             "cache_creation_input_tokens": 3_824,
+             "cache_read_input_tokens": 20_000,
+             "output_tokens": 999_999,
+         }},
         env={"CLAUDE_CODE_AUTO_COMPACT_WINDOW": "400000"},
     )
     assert ctx_pct is None          # unknown stays unknown
     assert ctx_size == 400_000      # but the window itself is corrected
-    assert ctx_used == 1234
+    assert ctx_used == 63_824       # output tokens never occupy context
+
+
+def test_exact_input_usage_rescales_against_override():
+    ctx_pct, ctx_size, ctx_used = _usage(
+        {"context_window_size": 1_000_000, "context_used_pct": 6,
+         "context_current_usage": {
+             "input_tokens": 40_000,
+             "cache_creation_input_tokens": 3_824,
+             "cache_read_input_tokens": 20_000,
+             "output_tokens": 999_999,
+         }},
+        env={"CLAUDE_CODE_AUTO_COMPACT_WINDOW": "400000"},
+    )
+    assert ctx_size == 400_000
+    assert ctx_used == 63_824
+    assert ctx_pct == pytest.approx(15.956)
 
 
 # --- CLAUDE_CODE_DISABLE_1M_CONTEXT ------------------------------------------


### PR DESCRIPTION
## Problem

On the first ticks of a resumed/new session, Claude Code 2.1.220 still sends the **cumulative session counter** as `context_window.total_input_tokens` (while `current_usage` is absent and `used_percentage` is null). Seen live: `Fable 5(73.6M/1.0M)` — 73.6M "context" tokens on a 1M window.

A version gate (`_CONTEXT_TOTALS_MIN_VERSION`) can't catch this: the field's meaning changes within a single version depending on lifecycle, so a version table can never keep up.

## Approach: trust tiers + invariant cross-check

1. **current_usage** (input + cache_creation + cache_read) — authoritative, kept verbatim even above the window size (a pending compact really does exceed it; seen live: 212k reported on a 200k window at 100%).
2. **total_input_tokens** — trusted only when it agrees with `used_percentage` within quantization tolerance (±1.5pct). A cumulative counter fails this check on every version, past and future.
3. **Derived from used_percentage.**
4. **None = unknown** (first tick / post-/compact sentinel, where pct and current_usage are both null) — renders as a bare model name instead of a fabricated `(0/1.0M)`.

`parse_stdin_data` now preserves absent-vs-explicit-null for `current_usage` and no longer defaults absent totals to 0, so the tiers can tell those states apart. `format_number` gains a B branch so a runaway value can never render as an ambiguous k/M string.

`_CONTEXT_TOTALS_MIN_VERSION` is deleted — one less version table to maintain.

## Verification

- New tests: cumulative counter rejected (73.6M vs 7% → 70k); totals accepted when consistent with pct; first tick all-null → no suffix; over-window current_usage kept verbatim; absent-vs-null distinguished.
- Full local suite (Windows): 1002 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context-window usage reporting by prioritizing validated current usage data.
  * Prevented misleading token counts when usage information is unavailable or inconsistent.
  * Correctly handles null, zero, cumulative, oversized, and malformed usage values.
  * Improved accuracy when a custom context-window limit is configured.

* **Tests**
  * Expanded coverage for usage parsing, percentage validation, version handling, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->