### PR TITLE
fix(fp): loopback relays are not fingerprintable endpoints

### DIFF
--- a/src/claude_statusbar/fp_risk.py
+++ b/src/claude_statusbar/fp_risk.py
@@ -11,6 +11,7 @@ timezone — and surfaces "this setup is fingerprintable, ban risk" so the
 user can make an informed call (the robust fix is the official endpoint).
 """
 import os
+from ipaddress import ip_address
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
@@ -21,16 +22,20 @@ _MARKED_TIMEZONES = {"Asia/Shanghai", "Asia/Urumqi"}
 
 
 def _relay_host(env: Dict[str, str]) -> Optional[str]:
-    """The relay host when ANTHROPIC_BASE_URL points off the official API,
-    else None (official / unset). Same host-parsing as no-quota detection."""
+    """Remote relay host, or None for official, loopback, or unset URLs."""
     base = (env.get("ANTHROPIC_BASE_URL") or "").strip()
     if not base:
         return None
     from urllib.parse import urlparse
     parsed = urlparse(base if "//" in base else "//" + base)
     host = (parsed.hostname or "").strip().rstrip(".").lower()
-    if not host or host == _OFFICIAL_API_HOST:
+    if not host or host == _OFFICIAL_API_HOST or host == "localhost":
         return None
+    try:
+        if ip_address(host).is_loopback:
+            return None
+    except ValueError:
+        pass
     return host
 
 

--- a/tests/test_fp_risk.py
+++ b/tests/test_fp_risk.py
@@ -1,6 +1,8 @@
 # Relay fingerprint-risk warning line (show_fp_risk): local-only inference —
 # relay base URL + a marked system timezone. Never touches the network or the
 # outgoing request; it only surfaces what the user's own env already implies.
+import pytest
+
 import claude_statusbar.fp_risk as fp_risk
 
 
@@ -12,6 +14,32 @@ def test_no_relay_is_silent(monkeypatch):
     text, _ = fp_risk.fp_risk_line(
         {"ANTHROPIC_BASE_URL": "https://api.anthropic.com"})
     assert text == ""
+
+
+@pytest.mark.parametrize("base_url", [
+    "HTTP://LOCALHOST:8787",
+    "http://127.0.0.1:8787",
+    "http://127.42.0.9:8787",
+    "http://[::1]:8787",
+])
+def test_loopback_base_url_is_silent(monkeypatch, base_url):
+    monkeypatch.setattr(fp_risk, "system_timezone", lambda: "Asia/Shanghai")
+    assert fp_risk.fp_risk_line(
+        {"ANTHROPIC_BASE_URL": base_url}
+    ) == ("", "ok")
+
+
+@pytest.mark.parametrize("base_url", [
+    "http://192.0.2.1:8787",
+    "http://[2001:db8::1]:8787",
+    "http://localhost.example.com:8787",
+    "http://127.0.0.1.example.com:8787",
+])
+def test_remote_and_loopback_lookalikes_still_warn(monkeypatch, base_url):
+    monkeypatch.setattr(fp_risk, "system_timezone", lambda: "America/New_York")
+    text, level = fp_risk.fp_risk_line({"ANTHROPIC_BASE_URL": base_url})
+    assert level == "warn"
+    assert "third-party relay" in text
 
 
 def test_relay_plus_marked_tz_is_crit(monkeypatch):

--- a/tests/test_no_quota_integration.py
+++ b/tests/test_no_quota_integration.py
@@ -61,6 +61,28 @@ def test_relay_env_forces_no_quota_layout(tmp_path, monkeypatch, capsys):
     assert "7d[" not in out
 
 
+def test_loopback_proxy_keeps_no_quota_without_fp_warning(
+        tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://127.0.0.1:17870")
+    monkeypatch.delenv("CS_API_MODE", raising=False)
+    _write_config(tmp_path, show_fp_risk=True)
+
+    import claude_statusbar.config as config
+    monkeypatch.setattr(
+        config, "CONFIG_PATH",
+        tmp_path / ".claude" / "claude-statusbar.json")
+    monkeypatch.setattr(sys, "stdin", io.StringIO(_payload_with_quota()))
+    from claude_statusbar.core import main
+    main(use_color=False, _suppress_side_effects=True)
+
+    out = capsys.readouterr().out
+    assert "ctx[" in out
+    assert "5h[" not in out
+    assert "7d[" not in out
+    assert "third-party relay" not in out
+    assert "account-ban risk" not in out
+
+
 def test_official_env_keeps_quota_layout(tmp_path, monkeypatch, capsys):
     """No relay env → unchanged: 5h/7d bars render, no ctx bar."""
     monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)

--- a/tests/test_no_quota_mode.py
+++ b/tests/test_no_quota_mode.py
@@ -10,12 +10,24 @@ Detection is a pure function of the process environment + an explicit
 override, so these tests feed env dicts directly.
 """
 
+import pytest
+
 from claude_statusbar import core
 
 
 def test_relay_base_url_triggers_no_quota():
     """ANTHROPIC_BASE_URL pointing at a third-party relay → no-quota mode."""
     assert core.is_no_quota_mode({"ANTHROPIC_BASE_URL": "https://relay.example.com"}) is True
+
+
+@pytest.mark.parametrize("base_url", [
+    "HTTP://LOCALHOST:8787",
+    "http://127.0.0.1:8787",
+    "http://127.42.0.9:8787",
+    "http://[::1]:8787",
+])
+def test_loopback_base_url_still_triggers_no_quota(base_url):
+    assert core.is_no_quota_mode({"ANTHROPIC_BASE_URL": base_url}) is True
 
 
 def test_official_base_url_does_not_trigger():


### PR DESCRIPTION
When `ANTHROPIC_BASE_URL` points at localhost/127.0.0.1 (a local model router such as claude-proxy), the fp-risk warning should not fire: the TLS fingerprint never leaves the machine. Loopback hosts are now treated like the official endpoint — no warning line — while no-quota detection from the same URL still works (tests cover both sides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)