### PR TITLE
feat(render): ANSI-aware width clipping for every render path

### DIFF
--- a/src/claude_statusbar/_display.py
+++ b/src/claude_statusbar/_display.py
@@ -1,0 +1,123 @@
+"""Small ANSI-aware display-width helpers shared by render paths."""
+import os
+import re
+import unicodedata
+from typing import Mapping, Optional
+
+_ANSI_RE = re.compile(
+    r"\x1b(?:"
+    r"\][^\x07\x1b]*(?:\x07|\x1b\\)"  # OSC
+    r"|\[[0-?]*[ -/]*[@-~]"             # CSI
+    r"|[ -/]*[@-~]"                      # other ESC sequence
+    r")"
+)
+_SGR_RE = re.compile(r"\x1b\[([0-9;:]*)m")
+_RESET = "\x1b[0m"
+
+
+def terminal_width(env: Optional[Mapping[str, str]] = None) -> Optional[int]:
+    """Positive COLUMNS from env, terminal size, or None when unavailable."""
+    source = os.environ if env is None else env
+    raw = source.get("COLUMNS")
+    try:
+        width = int(str(raw).strip())
+    except (TypeError, ValueError):
+        width = 0
+    if width > 0:
+        return width
+    try:
+        width = os.get_terminal_size().columns
+    except OSError:
+        return None
+    return width if width > 0 else None
+
+
+def _char_width(char: str) -> int:
+    if unicodedata.combining(char):
+        return 0
+    category = unicodedata.category(char)
+    if category in {"Cf", "Cc", "Cs"}:
+        return 0
+    return 2 if unicodedata.east_asian_width(char) in {"W", "F"} else 1
+
+
+def visible_width(text: str) -> int:
+    """Terminal-cell width, excluding ANSI control sequences."""
+    width = 0
+    pos = 0
+    for match in _ANSI_RE.finditer(text):
+        width += sum(_char_width(char) for char in text[pos:match.start()])
+        pos = match.end()
+    return width + sum(_char_width(char) for char in text[pos:])
+
+
+def _sgr_active(active: bool, sequence: str) -> bool:
+    match = _SGR_RE.fullmatch(sequence)
+    if match is None:
+        return active
+    params = match.group(1)
+    if not params:
+        return False
+    reset_codes = {"", "22", "23", "24", "25", "27", "28", "29", "39", "49"}
+    for value in params.replace(":", ";").split(";"):
+        if value == "0":
+            active = False
+        elif value not in reset_codes:
+            active = True
+    return active
+
+
+def clip_line(text: str, max_width: Optional[int], ellipsis: str = "…") -> str:
+    """Clip one physical line without splitting ANSI sequences."""
+    if max_width is None or visible_width(text) <= max_width:
+        return text
+    if max_width <= 0:
+        return ""
+
+    ellipsis_width = visible_width(ellipsis)
+    if ellipsis_width > max_width:
+        return ""
+    content_limit = max_width - ellipsis_width
+    output = []
+    used = 0
+    active_sgr = False
+    pos = 0
+
+    for match in _ANSI_RE.finditer(text):
+        for char in text[pos:match.start()]:
+            char_width = _char_width(char)
+            if used + char_width > content_limit:
+                clipped = "".join(output) + ellipsis
+                return clipped + (_RESET if active_sgr else "")
+            output.append(char)
+            used += char_width
+        sequence = match.group(0)
+        output.append(sequence)
+        active_sgr = _sgr_active(active_sgr, sequence)
+        pos = match.end()
+
+    for char in text[pos:]:
+        char_width = _char_width(char)
+        if used + char_width > content_limit:
+            clipped = "".join(output) + ellipsis
+            return clipped + (_RESET if active_sgr else "")
+        output.append(char)
+        used += char_width
+
+    return text
+
+
+def clip_lines(text: str, max_width: Optional[int]) -> str:
+    """Clip each physical line independently, preserving line endings."""
+    if max_width is None or not text:
+        return text
+    output = []
+    for part in text.splitlines(keepends=True):
+        if part.endswith("\r\n"):
+            line, ending = part[:-2], "\r\n"
+        elif part.endswith(("\n", "\r")):
+            line, ending = part[:-1], part[-1:]
+        else:
+            line, ending = part, ""
+        output.append(clip_line(line, max_width) + ending)
+    return "".join(output)

--- a/src/claude_statusbar/core.py
+++ b/src/claude_statusbar/core.py
@@ -1037,15 +1037,6 @@ def main(json_output: bool = False,
         hot=parse_hex_color(cfg.color_hot) if cfg.color_hot else None,
     )
 
-    # Auto-compact: if terminal narrower than threshold, force hairline
-    if cfg.auto_compact_width > 0 and chosen_style != "hairline":
-        try:
-            term_w = os.get_terminal_size().columns
-            if term_w < cfg.auto_compact_width:
-                chosen_style = "hairline"
-        except OSError:
-            pass
-
     stdin_data = parse_stdin_data()
 
     # No-quota mode (third-party relay / Bedrock / Vertex): official 5h/7d quota
@@ -1058,6 +1049,13 @@ def main(json_output: bool = False,
     # this session's, so reading it would mis-detect no-quota mode per session.
     _session_env = stdin_data.get('_session_env')
     _effective_env = _session_env if isinstance(_session_env, dict) else os.environ
+    from ._display import clip_lines as _clip_lines
+    from ._display import terminal_width as _terminal_width
+    max_width = _terminal_width(_effective_env)
+    # Auto-compact and final clipping share one per-session width source.
+    if (cfg.auto_compact_width > 0 and chosen_style != "hairline"
+            and max_width is not None and max_width < cfg.auto_compact_width):
+        chosen_style = "hairline"
     _api_mode = _cfg.resolve_api_mode(cfg, env=_effective_env)
     no_quota = is_no_quota_mode(_effective_env, override=_api_mode)
     # Heuristic fallback only when the env signal missed (and not force-disabled):
@@ -1328,6 +1326,7 @@ def main(json_output: bool = False,
                     density=cfg.density, show_weekly=cfg.show_weekly,
                     ctx_pct=ctx_pct,
                     shimmer_phase=shimmer_phase,
+                    max_width=max_width,
                     no_quota=True,
                     balance_text=balance_text,
                     balance_pct=balance_pct,
@@ -1452,6 +1451,7 @@ def main(json_output: bool = False,
                     density=cfg.density, show_weekly=cfg.show_weekly,
                     ctx_pct=ctx_pct,
                     shimmer_phase=shimmer_phase,
+                    max_width=max_width,
                     **projection_kwargs,
                     **forecast_kwargs,
                     **identity_kwargs, **cwd_kwargs, **party_kwargs, **mode_kwargs, **ip_line_kwargs, **fp_line_kwargs,
@@ -1509,6 +1509,7 @@ def main(json_output: bool = False,
                         density=cfg.density, show_weekly=cfg.show_weekly,
                         ctx_pct=ctx_pct,
                         shimmer_phase=shimmer_phase,
+                        max_width=max_width,
                         quota_stale=quota_stale,
                         **identity_kwargs, **cwd_kwargs, **party_kwargs, **mode_kwargs, **ip_line_kwargs, **fp_line_kwargs,
                         **activity_kwargs,
@@ -1523,7 +1524,8 @@ def main(json_output: bool = False,
                                  "bypass": bypass},
                     }))
                 else:
-                    print(f"⚠ Run inside Claude Code statusLine for rate-limit data | {model}")
+                    warning = f"⚠ Run inside Claude Code statusLine for rate-limit data | {model}"
+                    print(_clip_lines(warning, max_width))
 
     except Exception as e:
         reset_time = calculate_reset_time(reset_hour=reset_hour).replace(" ", "")
@@ -1542,6 +1544,7 @@ def main(json_output: bool = False,
                 warning_threshold=warning_threshold,
                 critical_threshold=critical_threshold,
                 density=cfg.density, show_weekly=cfg.show_weekly,
+                max_width=max_width,
                 **identity_kwargs, **cwd_kwargs, **party_kwargs, **mode_kwargs, **ip_line_kwargs, **fp_line_kwargs,
             ))
 

--- a/src/claude_statusbar/render_thin.py
+++ b/src/claude_statusbar/render_thin.py
@@ -23,6 +23,8 @@ import json
 import os
 import sys
 import time
+
+from ._display import clip_lines, terminal_width
 from pathlib import Path
 
 # Same constants as daemon.py — keep in sync. Duplicated rather than
@@ -295,6 +297,7 @@ _SESSION_ENV_KEYS = (
     "CS_API_MODE",
     "CLAUDE_CODE_USE_BEDROCK",
     "CLAUDE_CODE_USE_VERTEX",
+    "COLUMNS",
 )
 
 
@@ -426,7 +429,8 @@ def _fallback_inline() -> int:
     buf = _io.StringIO()
     with contextlib.redirect_stdout(buf):
         core_main()
-    sys.stdout.write(_append_suffix(buf.getvalue(), _displacement_suffix()))
+    content = _append_suffix(buf.getvalue(), _displacement_suffix())
+    sys.stdout.write(clip_lines(content, terminal_width(os.environ)))
     return 0
 
 
@@ -454,8 +458,11 @@ def render() -> int:
     meta = _read_meta(meta_path)
     if meta is not None and _is_fresh(meta):
         try:
-            content = rendered_path.read_text(encoding="utf-8")
-            sys.stdout.write(_append_suffix(content, _displacement_suffix()))
+            content = _append_suffix(
+                rendered_path.read_text(encoding="utf-8"),
+                _displacement_suffix(),
+            )
+            sys.stdout.write(clip_lines(content, terminal_width(os.environ)))
             return 0
         except OSError:
             # rendered.ansi disappeared between the meta read and the read.

--- a/src/claude_statusbar/styles.py
+++ b/src/claude_statusbar/styles.py
@@ -10,6 +10,7 @@ Adding a new style:
 
 from typing import Optional
 
+from ._display import clip_line, clip_lines, visible_width
 from .themes import Theme, get_theme
 
 RESET = "\033[0m"
@@ -561,25 +562,8 @@ def render_activity_line(activity, *, theme: Theme, use_color: bool = True,
 
 
 def _clip_width(s: str, limit: int) -> str:
-    """Truncate `s` to `limit` display columns, appending … when cut.
-
-    Wide East-Asian glyphs count as two columns, so a CJK preview clips at the
-    same visual width as an ASCII one.
-    """
-    from unicodedata import east_asian_width
-
-    def w(ch):
-        return 2 if east_asian_width(ch) in ("W", "F") else 1
-
-    if sum(w(ch) for ch in s) <= limit:
-        return s
-    out, used = [], 0
-    for ch in s:
-        if used + w(ch) > limit - 1:
-            break
-        out.append(ch)
-        used += w(ch)
-    return "".join(out) + "…"
+    """Back-compatible wrapper around shared ANSI-aware clipping."""
+    return clip_line(s, limit)
 
 
 def render_party_line(party, *, theme: Theme, use_color: bool = True) -> str:
@@ -828,6 +812,7 @@ def render(style: str, **kwargs) -> str:
     append an 'activity' line (todos / active tool / session stats) plus one
     bottom line per running subagent. All extra lines are style-agnostic.
     """
+    max_width = kwargs.pop("max_width", None)
     show_pb = kwargs.pop("show_project_branch", False)
     info = kwargs.pop("identity", None)
     dirty = kwargs.pop("identity_dirty", None)
@@ -855,7 +840,42 @@ def render(style: str, **kwargs) -> str:
     use_color = kwargs.get("use_color", True)
 
     fn = RENDERERS.get(style, render_classic)
-    out = fn(**kwargs)
+    render_kwargs = dict(kwargs)
+    out = fn(**render_kwargs)
+
+    # Preserve core quota/model signal before hard clipping. Optional segments
+    # disappear in stable least-important-first order; selected style stays put.
+    if (max_width is not None and max_width > 0
+            and visible_width(out.split("\n", 1)[0]) > max_width):
+        degradation = (
+            {"cache_age_text": ""},
+            {"lang_body": ""},
+            {"cost_text": ""},
+            {"balance_text": "", "balance_pct": None, "balance_amount": ""},
+            {"forecast_5h": "", "forecast_7d": ""},
+            {"projection_5h": "", "projection_7d": ""},
+        )
+        for replacements in degradation:
+            render_kwargs.update(replacements)
+            out = fn(**render_kwargs)
+            if visible_width(out.split("\n", 1)[0]) <= max_width:
+                break
+        else:
+            # Context tokens go last, and in two steps: drop the window
+            # denominator first — "Opus 5(139.3k/1.0M)" → "Opus 5(139.3k)" buys
+            # ~6 columns and keeps the number people actually read. A ~70-col
+            # pane on a 1M-context model lands exactly here, so dropping
+            # straight to a bare model name loses the count for no reason.
+            import re
+            model = str(render_kwargs.get("model", ""))
+            m = re.search(r"\s*\(([^()\n]*)/[^()\n]*\)$", model)
+            if m:
+                head = model[:m.start()]
+                for candidate in (f"{head}({m.group(1)})", head):
+                    render_kwargs["model"] = candidate
+                    out = fn(**render_kwargs)
+                    if visible_width(out.split("\n", 1)[0]) <= max_width:
+                        break
 
     if show_pb and info is not None:
         version_text = _statusbar_version() if show_version else ""
@@ -882,9 +902,8 @@ def render(style: str, **kwargs) -> str:
 
     # Dedicated egress-IP risk warning — appears only above the risk threshold
     # (ip_risk.SHOW_THRESHOLD), amber for suspicious, red for bad. May be
-    # multi-line (summary + action); each sub-line is colored separately so a
-    # long warning wraps cleanly instead of being truncated. Not part of the
-    # git identity line: network state isn't repo identity.
+    # multi-line (summary + action); each sub-line is colored separately, then
+    # final width clipping applies per physical line. Not part of git identity.
     def _emit_risk(text, level):
         nonlocal out
         if not text:
@@ -917,7 +936,7 @@ def render(style: str, **kwargs) -> str:
             for agline in render_agent_lines(
                     activity.agents, theme=theme, use_color=use_color):
                 out = out + "\n" + agline
-    return out
+    return clip_lines(out, max_width)
 
 
 def list_styles() -> list[str]:

--- a/tests/test_core_width.py
+++ b/tests/test_core_width.py
@@ -1,0 +1,102 @@
+import io
+import json
+import os
+import sys
+
+import pytest
+
+from claude_statusbar._display import visible_width
+
+
+def _payload(session_env):
+    return json.dumps({
+        "session_id": "width",
+        "version": "2.1.220",
+        "model": {"id": "claude-opus-5", "display_name": "Opus 5"},
+        "rate_limits": {
+            "five_hour": {"used_percentage": 42, "resets_at": 9999999999},
+            "seven_day": {"used_percentage": 18, "resets_at": 9999999999},
+        },
+        "context_window": {
+            "used_percentage": 6,
+            "context_window_size": 1_000_000,
+            "current_usage": {
+                "input_tokens": 40_000,
+                "cache_creation_input_tokens": 3_824,
+                "cache_read_input_tokens": 20_000,
+                "output_tokens": 999_999,
+            },
+        },
+        "_cs_env": session_env,
+    })
+
+
+def _run(tmp_path, monkeypatch, capsys, session_env, terminal_width=None):
+    config_path = tmp_path / ".claude" / "claude-statusbar.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(json.dumps({
+        "style": "classic",
+        "auto_compact_width": 60,
+        "show_project_branch": False,
+        "show_cache_age": False,
+        "show_todos": False,
+        "show_mode": False,
+        "show_party": False,
+        "show_version": False,
+    }), encoding="utf-8")
+
+    import claude_statusbar.config as config
+    import claude_statusbar.styles as styles
+    from claude_statusbar import _display
+    from claude_statusbar.core import main
+
+    monkeypatch.setattr(config, "CONFIG_PATH", config_path)
+    if terminal_width is None:
+        def unavailable():
+            raise OSError
+        monkeypatch.setattr(_display.os, "get_terminal_size", unavailable)
+    else:
+        monkeypatch.setattr(
+            _display.os, "get_terminal_size",
+            lambda: os.terminal_size((terminal_width, 24)),
+        )
+    monkeypatch.setattr(sys, "stdin", io.StringIO(_payload(session_env)))
+
+    seen = {}
+    original = styles.render
+
+    def capture(style, **kwargs):
+        seen["style"] = style
+        seen["max_width"] = kwargs.get("max_width")
+        return original(style, **kwargs)
+
+    monkeypatch.setattr(styles, "render", capture)
+    main(use_color=False, _suppress_side_effects=True)
+    return seen, capsys.readouterr().out
+
+
+@pytest.mark.parametrize("session_env", [
+    {"COLUMNS": "36"},
+    {"COLUMNS": "36", "ANTHROPIC_BASE_URL": "http://127.0.0.1:17870"},
+])
+def test_session_columns_drives_auto_compact_and_hard_cap(
+        tmp_path, monkeypatch, capsys, session_env):
+    seen, out = _run(tmp_path, monkeypatch, capsys, session_env)
+    assert seen == {"style": "hairline", "max_width": 36}
+    assert all(visible_width(line) <= 36 for line in out.splitlines())
+
+
+@pytest.mark.parametrize("bad", ["", "0", "-5", "nope"])
+def test_invalid_columns_uses_terminal_fallback(
+        tmp_path, monkeypatch, capsys, bad):
+    seen, out = _run(
+        tmp_path, monkeypatch, capsys, {"COLUMNS": bad}, terminal_width=50)
+    assert seen == {"style": "hairline", "max_width": 50}
+    assert all(visible_width(line) <= 50 for line in out.splitlines())
+
+
+def test_unavailable_width_preserves_unbounded_style(
+        tmp_path, monkeypatch, capsys):
+    seen, out = _run(tmp_path, monkeypatch, capsys, {"COLUMNS": "bad"})
+    assert seen == {"style": "classic", "max_width": None}
+    assert out

--- a/tests/test_display_width.py
+++ b/tests/test_display_width.py
@@ -1,0 +1,58 @@
+import os
+
+from claude_statusbar import _display
+
+
+def test_terminal_width_prefers_positive_columns(monkeypatch):
+    monkeypatch.setattr(_display.os, "get_terminal_size", lambda: os.terminal_size((80, 24)))
+    assert _display.terminal_width({"COLUMNS": "42"}) == 42
+
+
+def test_terminal_width_falls_back_to_terminal(monkeypatch):
+    monkeypatch.setattr(_display.os, "get_terminal_size", lambda: os.terminal_size((80, 24)))
+    for value in (None, "", "0", "-1", "nope"):
+        assert _display.terminal_width({"COLUMNS": value}) == 80
+
+
+def test_terminal_width_unavailable(monkeypatch):
+    def unavailable():
+        raise OSError
+
+    monkeypatch.setattr(_display.os, "get_terminal_size", unavailable)
+    assert _display.terminal_width({}) is None
+
+
+def test_terminal_width_defaults_to_process_env(monkeypatch):
+    monkeypatch.setenv("COLUMNS", "53")
+    assert _display.terminal_width() == 53
+
+
+def test_visible_width_ignores_ansi_and_counts_unicode_cells():
+    assert _display.visible_width("\x1b[31mred\x1b[0m") == 3
+    assert _display.visible_width("A界B") == 4
+    assert _display.visible_width("é") == 1
+    assert _display.visible_width("A‍B") == 2
+
+
+def test_clip_line_plain_and_tiny_limits():
+    assert _display.clip_line("abcdef", 4) == "abc…"
+    assert _display.clip_line("abcdef", 1) == "…"
+    assert _display.clip_line("abcdef", 0) == ""
+    assert _display.clip_line("abc", 3) == "abc"
+
+
+def test_clip_line_does_not_split_wide_or_combining_characters():
+    assert _display.clip_line("A界BC", 4) == "A界…"
+    assert _display.clip_line("éxyz", 3) == "éx…"
+
+
+def test_clip_line_preserves_ansi_and_resets_active_color():
+    clipped = _display.clip_line("\x1b[31mabcdef", 4)
+    assert clipped == "\x1b[31mabc…\x1b[0m"
+    assert _display.visible_width(clipped) == 4
+    assert not _display.clip_line("\x1b[31;0mabcdef", 4).endswith("\x1b[0m")
+
+
+def test_clip_lines_preserves_boundaries_and_trailing_newline():
+    text = "abcdef\nxy\r\n12345\n"
+    assert _display.clip_lines(text, 4) == "abc…\nxy\r\n123…\n"

--- a/tests/test_render_thin_stdin.py
+++ b/tests/test_render_thin_stdin.py
@@ -107,3 +107,25 @@ def test_session_id_survives_the_bounded_read(monkeypatch):
 ])
 def test_payload_completeness_check(buf, expected):
     assert render_thin._payload_is_complete(buf) is expected
+
+
+def test_session_env_injection_includes_columns(monkeypatch):
+    monkeypatch.setenv("COLUMNS", "41")
+    stamped = json.loads(render_thin._inject_session_env(PAYLOAD))
+    assert stamped["_cs_env"]["COLUMNS"] == "41"
+
+
+def test_cached_output_clips_after_displacement_suffix(tmp_path, monkeypatch, capsys):
+    rendered = tmp_path / "rendered.ansi"
+    meta = tmp_path / "meta.json"
+    rendered.write_text("1234567890\n", encoding="utf-8")
+    monkeypatch.setattr(render_thin, "_consume_stdin", lambda: None)
+    monkeypatch.setattr(render_thin, "_session_paths",
+                        lambda _sid: (tmp_path, rendered, meta))
+    monkeypatch.setattr(render_thin, "_read_meta", lambda _path: {})
+    monkeypatch.setattr(render_thin, "_is_fresh", lambda _meta: True)
+    monkeypatch.setattr(render_thin, "_displacement_suffix", lambda: " SUFFIX")
+    monkeypatch.setenv("COLUMNS", "8")
+
+    assert render_thin.render() == 0
+    assert capsys.readouterr().out == "1234567…\n"

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from claude_statusbar._display import visible_width
 from claude_statusbar.styles import (
     DENSITY_PAD,
     RENDERERS,
@@ -56,6 +57,64 @@ def test_every_combination_renders(style, theme):
 def test_no_color_strips_all_ansi(style):
     out = render(style, theme=get_theme("graphite"), use_color=False, **SAMPLE)
     assert "\033[" not in out, f"{style} leaked ANSI when use_color=False"
+
+
+@pytest.mark.parametrize("style", list(RENDERERS))
+@pytest.mark.parametrize("use_color", [False, True])
+def test_max_width_caps_every_physical_line(style, use_color):
+    out = render(
+        style, theme=get_theme("graphite"), use_color=use_color,
+        max_width=38, cost_text="123.45", cache_age_text="COLD",
+        forecast_5h="→99%", forecast_7d="→98%",
+        projection_5h="→97%", projection_7d="→96%",
+        fp_line_text="⚠ third-party relay warning with long action text",
+        fp_line_level="warn", **SAMPLE,
+    )
+    assert all(visible_width(line) <= 38 for line in out.splitlines())
+
+
+@pytest.mark.parametrize("style", list(RENDERERS))
+def test_max_width_is_noop_when_output_already_fits(style):
+    kwargs = dict(theme=get_theme("graphite"), use_color=False, **SAMPLE)
+    assert render(style, **kwargs, max_width=500) == render(style, **kwargs)
+
+
+@pytest.mark.parametrize("style", list(RENDERERS))
+def test_context_suffix_is_complete_or_omitted(style):
+    out = render(
+        style, theme=get_theme("graphite"), use_color=False, max_width=34,
+        cost_text="123.45", cache_age_text="COLD", **SAMPLE,
+    )
+    assert "45.0k/1.0M" not in out or "(45.0k/1.0M)" in out
+    assert all(fragment not in out for fragment in ("(45.0k/", "45.0k/1.0…"))
+
+
+def test_context_denominator_drops_before_the_whole_count():
+    """A width that fits "(45.0k)" but not "(45.0k/1.0M)" keeps the count."""
+    sample = dict(SAMPLE, lang_body="")  # nothing optional left to sacrifice
+    full = render("capsule", theme=get_theme("graphite"), use_color=False,
+                  **sample)
+    width = visible_width(full.split("\n", 1)[0]) - 4  # loses "/1.0M", not more
+    out = render("capsule", theme=get_theme("graphite"), use_color=False,
+                 max_width=width, **sample)
+    assert "(45.0k)" in out
+    assert "45.0k/1.0M" not in out
+
+
+def test_optional_degradation_order_is_stable(monkeypatch):
+    calls = []
+
+    def probe(**kwargs):
+        calls.append((kwargs.get("cache_age_text"), kwargs.get("lang_body")))
+        return "0123456789" + kwargs.get("cache_age_text", "") + kwargs.get("lang_body", "")
+
+    monkeypatch.setitem(RENDERERS, "probe", probe)
+    out = render(
+        "probe", max_width=10, cache_age_text="CACHE", lang_body="LANG",
+        theme=get_theme("graphite"), use_color=False,
+    )
+    assert calls[:3] == [("CACHE", "LANG"), ("", "LANG"), ("", "")]
+    assert out == "0123456789"
 
 
 def test_unknown_style_falls_back_to_classic():


### PR DESCRIPTION
## Problem

In narrow terminals the status line gets hard-truncated by Claude Code: ANSI sequences are cut mid-escape (leaking codes, bleeding colors), CJK wide glyphs are counted as 1 column, and the model's context suffix gets sliced into fragments like `(73.`.

## Approach

New `_display` module as the single source of width/clipping:

- `terminal_width`: COLUMNS env first (daemon renders use the session's own width — render_thin now stamps COLUMNS into the per-session env), falling back to `os.get_terminal_size`.
- `visible_width` / `clip_line` / `clip_lines`: ANSI/OSC-aware, wide glyphs count as 2 columns, escape sequences are never split, and an active SGR is reset before the ellipsis at the cut point.
- `styles.render` degrades gracefully before hard clipping: optional segments drop in a stable least-important-first order (cache age → lang → cost → balance → forecast → projection), then the model's context suffix is removed whole — a suffix is complete or absent, never sliced mid-number.
- core's auto-compact style switching reuses the same width source; the outside-statusline warning line clips too.

`styles._clip_width` becomes a thin wrapper over the shared `clip_line`.

## Verification

New test_display_width / test_core_width plus styles/render_thin cases; full local suite (Windows) 967 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic terminal-width detection using environment settings or terminal dimensions.
  - Long status-bar output now clips cleanly to the available width.
  - ANSI colors, Unicode characters, line breaks, and trailing newlines are preserved during clipping.
  - Status details progressively simplify to remain readable in narrow terminals.
  - Auto-compaction now uses the detected terminal width.

- **Bug Fixes**
  - Prevented styled output from overflowing narrow terminals or leaving color formatting active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->