### PR TITLE
fix: Windows statusLine written shell-safe; daily self-heal repairs instead of churning (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ For a quick overview of the latest release, see the
 
 ---
 
+## Unreleased
+
+**Windows: statusLine no longer written (or daily-reverted) to a shell-dead backslash path ([#42](https://github.com/leeguooooo/claude-code-usage-bar/issues/42)).**
+
+Claude Code executes the `statusLine` command through a POSIX shell (Git Bash on Windows), where `\` is an escape character — `C:\Users\me\cs.EXE` execs as `C:Usersmecs.EXE` and dies with exit 127 even though the file exists. `_resolve_cs_command()` returned `shutil.which()`'s backslash path verbatim, so on Windows the bar was broken from the very first write, and the daily self-heal reverted any hand-fix within 24h because it compared command strings for equality against that same poisoned path.
+
+- Paths are now written with forward slashes (valid in sh *and* cmd.exe), double-quoted when they contain spaces (double because cmd.exe has no single-quote semantics).
+- The daily self-heal now repairs only *broken* entries instead of anything that differs from today's canonical form: a working hand-fix, the fast/inline choice, and user-added CLI flags all survive. Repairs replace only the executable token — the argument tail is preserved verbatim (the old pass silently stripped flags like `--no-auto-update`). Bare `cs` is still upgraded to an absolute path once (GUI-launched Claude Code PATH gaps), and dead paths are still re-resolved.
+- Already-poisoned installs heal themselves on the next daily pass: a backslash executable is rewritten in place to forward slashes.
+- `cs doctor` gained a **statusLine shell test**: it runs the *configured* settings.json command string through `sh` — the render smoke test builds its own argv, which is exactly why this class of breakage stayed invisible. On Windows a backslash command is flagged statically.
+
+---
+
 ## v3.32.3 — 2026-07-27
 
 **Installer polish — three papercuts visible on every re-install.**

--- a/src/claude_statusbar/doctor.py
+++ b/src/claude_statusbar/doctor.py
@@ -125,8 +125,9 @@ def _statusline_shell_check(cmd: str, cache: Path) -> None:
     This check runs what Claude Code actually runs.
     """
     import subprocess
+    from .setup import _is_windows
 
-    if os.name == "nt" and "\\" in cmd:
+    if _is_windows() and "\\" in cmd:
         # No need to exec anything — sh will mangle this before the OS ever
         # sees a path. Diagnosable statically.
         _line("statusLine shell test",
@@ -337,6 +338,9 @@ def run() -> int:
     try:
         if sl_cmd:
             _statusline_shell_check(sl_cmd, cache)
+        else:
+            _line("statusLine shell test",
+                  _dim("skipped — no statusLine entry recognized as ours"))
     except Exception as e:
         _line("statusLine shell test", _dim(f"check skipped: {e}"))
 

--- a/src/claude_statusbar/doctor.py
+++ b/src/claude_statusbar/doctor.py
@@ -114,6 +114,61 @@ def _render_smoke_test(cache: Path) -> None:
     _line("render smoke test", f"ok — {len(out)} bytes rendered")
 
 
+def _statusline_shell_check(cmd: str, cache: Path) -> None:
+    """Exec the *configured* settings.json command string through `sh`.
+
+    The render smoke test above builds its own argv, so it stays green even
+    when the configured string itself is shell-dead — exactly issue #42: a
+    backslash Windows path passes every filesystem check, but Claude Code
+    runs the statusLine string through Git Bash's sh, which eats the
+    backslashes (`C:\\Users\\me\\cs.EXE` → `C:Usersmecs.EXE`, exit 127).
+    This check runs what Claude Code actually runs.
+    """
+    import subprocess
+
+    if os.name == "nt" and "\\" in cmd:
+        # No need to exec anything — sh will mangle this before the OS ever
+        # sees a path. Diagnosable statically.
+        _line("statusLine shell test",
+              _red("backslash path — Git Bash eats `\\` before exec; "
+                   "run: cs --setup"), ok=False)
+        return
+
+    sh = shutil.which("sh")
+    if sh is None:
+        _line("statusLine shell test",
+              _dim("skipped — no sh on PATH to emulate Claude Code's exec"))
+        return
+
+    payload = b"{}"
+    try:
+        if cache.exists():
+            payload = cache.read_bytes()
+    except OSError:
+        pass
+
+    try:
+        proc = subprocess.run([sh, "-c", cmd], input=payload,
+                              capture_output=True, timeout=30)
+    except Exception as e:
+        _line("statusLine shell test",
+              _red(f"could not run: {type(e).__name__}: {e}"), ok=False)
+        return
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or b"").decode("utf-8", "replace").strip()
+        tail = stderr.splitlines()[-1] if stderr else f"exit {proc.returncode}"
+        _line("statusLine shell test",
+              _red(f"exit {proc.returncode} — {tail}"), ok=False)
+        print(f"      {_dim('the configured command fails in the shell Claude Code uses')}")
+        return
+    if not (proc.stdout or b"").strip():
+        _line("statusLine shell test",
+              _red("rendered nothing — status line would be blank"), ok=False)
+        return
+    _line("statusLine shell test", "ok — configured command renders via sh")
+
+
 _ISSUES_URL = "https://github.com/leeguooooo/claude-code-usage-bar/issues"
 
 
@@ -143,6 +198,7 @@ def run() -> int:
     _line("python", f"{sys.version.split()[0]}  ({sys.executable})")
 
     # --- ~/.claude/settings.json statusLine entry ---
+    sl_cmd = None  # set when the entry is ours; drives the shell test below
     settings_path = Path.home() / ".claude" / "settings.json"
     if settings_path.exists():
         try:
@@ -155,6 +211,8 @@ def run() -> int:
             cmd = sl["command"]
             from .setup import _is_our_statusline, _existing_uses_render
             ours = _is_our_statusline(sl)
+            if ours:
+                sl_cmd = cmd
             _line("statusLine entry",
                   f"{cmd}  {_green('(ours)') if ours else _red('(not ours)')}",
                   ok=ours)
@@ -272,6 +330,15 @@ def run() -> int:
         _render_smoke_test(cache)
     except Exception as e:  # doctor must never die on its own check
         _line("render smoke test", _dim(f"check skipped: {e}"))
+
+    # --- statusLine shell test ---
+    # The smoke test proves *our code* renders; this proves the *configured
+    # command string* survives the shell Claude Code execs it through.
+    try:
+        if sl_cmd:
+            _statusline_shell_check(sl_cmd, cache)
+    except Exception as e:
+        _line("statusLine shell test", _dim(f"check skipped: {e}"))
 
     # --- terminal ---
     try:

--- a/src/claude_statusbar/setup.py
+++ b/src/claude_statusbar/setup.py
@@ -12,9 +12,10 @@ installs.
 
 import json
 import os
+import shlex
 import shutil
 import sys
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Optional, Tuple
 
 from .cache import atomic_write_text
@@ -46,6 +47,62 @@ def _normalize_command_name(name: str) -> str:
         if name.endswith(ext):
             return name[: -len(ext)]
     return name
+
+
+def _is_windows() -> bool:
+    """Module-level so tests can monkeypatch the platform."""
+    return os.name == "nt"
+
+
+def _shell_path(p: str) -> str:
+    """Make a path safe to embed in the statusLine command string.
+
+    Claude Code executes that string through a POSIX shell (Git Bash on
+    Windows), where `\\` is an escape character: `C:\\Users\\me\\cs.EXE`
+    execs as `C:Usersmecs.EXE` and dies with exit 127 even though the file
+    exists (issue #42). Forward slashes work in every shell involved —
+    sh, and cmd.exe too for full paths.
+
+    Quoting uses double quotes, not shlex.quote: shlex emits single quotes,
+    which sh honors but cmd.exe does not treat as quoting at all.
+    """
+    if "\\" in p:
+        p = PureWindowsPath(p).as_posix()
+    if " " in p:
+        return f'"{p}"'
+    return p
+
+
+def _command_tokens(cmd: str) -> list:
+    """Tokenize a statusLine command without destroying Windows paths.
+
+    shlex.split(posix=True) treats `\\` as an escape — the exact mangling
+    this module exists to prevent — so a poisoned `C:\\Users\\me\\cs.EXE`
+    entry would tokenize to garbage, read as foreign, and be exempted from
+    healing. Non-posix mode preserves backslashes but leaves quote marks
+    attached to tokens; strip those.
+    """
+    try:
+        tokens = shlex.split(cmd.strip(), posix=False)
+    except ValueError:  # unbalanced quotes — degrade to whitespace split
+        tokens = cmd.strip().split()
+    return [t.strip('"\'') for t in tokens]
+
+
+def _split_command(cmd: str) -> Tuple[str, str]:
+    """Split into (executable token, verbatim tail).
+
+    The tail keeps its original spacing and quoting so a repair can replace
+    only the executable and re-attach user-added flags untouched.
+    """
+    s = cmd.strip()
+    try:
+        raw = shlex.split(s, posix=False)
+    except ValueError:
+        raw = s.split()
+    if not raw:
+        return "", ""
+    return raw[0].strip('"\''), s[len(raw[0]):]
 
 
 def _resolve_cs_command() -> str:
@@ -100,7 +157,7 @@ def _statusline_config(fast: bool = False, refresh_interval: int = DEFAULT_REFRE
     countdown actually animates. Without it, Claude Code only re-renders
     on activity (turn complete, tool use), and time-based segments freeze.
     """
-    cmd = _resolve_cs_command()
+    cmd = _shell_path(_resolve_cs_command())
     if fast:
         cmd = f"{cmd} render"
     return {
@@ -131,7 +188,16 @@ def _is_our_statusline(entry: object) -> bool:
         return False
     if _invokes_our_module(cmd):
         return True
-    name = _normalize_command_name(Path(cmd.strip().split()[0]).name)  # strip args + path + .exe shim
+    tokens = _command_tokens(cmd)
+    if not tokens:
+        return False
+    # PureWindowsPath understands both separators, so a backslash entry is
+    # recognized as ours on any platform — it has to be, or the daily heal
+    # would treat a poisoned Windows entry as foreign and never fix it.
+    try:
+        name = _normalize_command_name(PureWindowsPath(tokens[0]).name)
+    except ValueError:
+        return False
     return name in OUR_COMMAND_NAMES
 
 
@@ -171,10 +237,60 @@ def _existing_uses_render(existing) -> bool:
     cmd = existing.get("command")
     if not isinstance(cmd, str):
         return False
-    parts = cmd.strip().split()
+    parts = _command_tokens(cmd)
     # `cs render`, and the module form `<python> -m claude_statusbar.cli render`
     # — in both, `render` is the last token.
     return len(parts) >= 2 and parts[-1] == "render"
+
+
+def _repair_command(cmd: str) -> Optional[str]:
+    """Return a repaired command string, or None when `cmd` is healthy.
+
+    Used by the daily self-heal for entries that are already ours. Drift is
+    defined as *broken*, not *different from today's canonical form* — the
+    old string-equality check reverted any Windows hand-fix back to a
+    backslash path every 24h (issue #42) and silently stripped user-added
+    CLI flags. A repair only ever replaces the executable token; the
+    argument tail survives verbatim.
+
+    Broken means one of:
+      - Windows + backslashes in the executable: the file may exist, but
+        Claude Code runs the string through Git Bash's sh, where `\\` is an
+        escape — shell-dead despite Path(...).is_file() saying healthy, so
+        this check must come before any filesystem probe.
+      - bare name (`cs`): works in a terminal, but GUI-launched Claude Code
+        often has a narrower PATH — upgrade to the absolute path.
+      - the executable path no longer exists (moved/reinstalled elsewhere).
+    """
+    tok0, tail = _split_command(cmd)
+    if not tok0:
+        return None
+
+    if _is_windows() and "\\" in tok0:
+        healed = PureWindowsPath(tok0).as_posix()
+        if Path(healed).is_file():
+            return _shell_path(healed) + tail
+        tok0 = healed  # separators fixed but target gone too — re-resolve below
+
+    if _invokes_our_module(cmd):
+        # Deliberate user choice (see _invokes_our_module) — never rewritten.
+        return None
+
+    if "/" not in tok0 and "\\" not in tok0:
+        candidate = _shell_path(_resolve_cs_command())
+        if candidate.strip('"') == tok0:
+            return None  # resolver found nothing better than the bare name
+        return candidate + tail
+
+    if not Path(tok0).is_file():
+        # Trust the resolver here: it already verified its non-fallback
+        # candidates, and second-guessing it would leave dead entries dead.
+        candidate = _shell_path(_resolve_cs_command())
+        if candidate.strip('"') == tok0:
+            return None
+        return candidate + tail
+
+    return None
 
 
 def ensure_statusline_configured(fast: Optional[bool] = None) -> Tuple[bool, str]:
@@ -220,22 +336,44 @@ def ensure_statusline_configured(fast: Optional[bool] = None) -> Tuple[bool, str
             f"manually if you want claude-statusbar."
         )
 
-    # Ours already. Determine effective_fast:
-    # - fast=None  → preserve user's existing choice
-    # - fast=bool  → respect it as an explicit user request
+    # Ours already.
     if fast is None:
-        effective_fast = _existing_uses_render(existing)
-    else:
-        effective_fast = fast
+        # Daily self-heal: repair only what is broken, never churn what
+        # merely differs from today's canonical form (fast/inline choice,
+        # user-added flags, hand-fixed separators all survive — issue #42).
+        changed = False
+        existing_cmd = existing.get("command")
+        if isinstance(existing_cmd, str):
+            repaired = _repair_command(existing_cmd)
+            if repaired is not None and repaired != existing_cmd:
+                existing["command"] = repaired
+                changed = True
+        existing_refresh = existing.get("refreshInterval")
+        if not (isinstance(existing_refresh, (int, float)) and existing_refresh > 0):
+            existing["refreshInterval"] = DEFAULT_REFRESH_INTERVAL
+            changed = True
+        if not changed:
+            return False, "statusLine already configured"
+        settings["statusLine"] = existing
+        if _write_settings(settings):
+            return True, (
+                f"Refreshed statusLine command to "
+                f"{existing.get('command')!r} in {SETTINGS_PATH}"
+            )
+        return False, f"Could not write to {SETTINGS_PATH}"
+
+    # Explicit `cs --setup [--fast|--inline]`: the user asked for a rewrite,
+    # so force the canonical form. This is the one path allowed to drop
+    # custom flags — an explicit request, unlike the daily pass above.
     existing_refresh = existing.get("refreshInterval")
     if isinstance(existing_refresh, (int, float)) and existing_refresh > 0:
         effective_refresh = int(existing_refresh)
     else:
         effective_refresh = DEFAULT_REFRESH_INTERVAL
-    desired = _statusline_config(fast=effective_fast, refresh_interval=effective_refresh)
+    desired = _statusline_config(fast=fast, refresh_interval=effective_refresh)
 
     # The module form is a deliberate choice (see `_invokes_our_module`), not
-    # drift — the daily repair pass must not rewrite it back to the console
+    # drift — even an explicit setup must not rewrite it back to the console
     # script. Keep the command, still refresh refreshInterval.
     existing_cmd = existing.get("command")
     if isinstance(existing_cmd, str) and _invokes_our_module(existing_cmd):

--- a/src/claude_statusbar/setup.py
+++ b/src/claude_statusbar/setup.py
@@ -270,6 +270,11 @@ def _repair_command(cmd: str) -> Optional[str]:
         healed = PureWindowsPath(tok0).as_posix()
         if Path(healed).is_file():
             return _shell_path(healed) + tail
+        if _invokes_our_module(cmd):
+            # A module-form command cannot be safely replaced with the `cs`
+            # console script, but its interpreter still needs shell-safe
+            # separators. Keep `-m claude_statusbar...` and every argument.
+            return _shell_path(healed) + tail
         tok0 = healed  # separators fixed but target gone too — re-resolve below
 
     if _invokes_our_module(cmd):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -38,6 +38,8 @@ def test_doctor_runs_clean_when_nothing_exists(capsys, _isolated):
     out = capsys.readouterr().out
     assert "cs doctor" in out
     assert "version" in out
+    assert "statusLine shell test" in out
+    assert "no statusLine entry recognized as ours" in out
 
 
 def test_doctor_runs_when_settings_is_corrupt(capsys, _isolated):
@@ -164,3 +166,14 @@ def test_render_argv_uses_dash_m_when_not_frozen(monkeypatch):
     import sys as _s
     monkeypatch.delattr(_s, "frozen", raising=False)
     assert doctor._render_argv()[1:] == ["-m", "claude_statusbar.cli", "render"]
+
+
+def test_shell_check_uses_patchable_windows_probe(
+        capsys, _isolated, monkeypatch):
+    from claude_statusbar import setup as setup_mod
+    monkeypatch.setattr(setup_mod, "_is_windows", lambda: True)
+    doctor._statusline_shell_check(
+        r"C:\Users\me\Scripts\cs.EXE", _isolated / "missing.json")
+    out = capsys.readouterr().out
+    assert "backslash path" in out
+    assert "run: cs --setup" in out

--- a/tests/test_setup_shell_path.py
+++ b/tests/test_setup_shell_path.py
@@ -186,6 +186,14 @@ def test_module_form_untouched_by_daily_pass(settings, monkeypatch):
     assert data["statusLine"]["command"] == mod_cmd
 
 
+def test_module_form_backslash_interpreter_is_posixized_when_missing(monkeypatch):
+    """A missing module interpreter still needs to survive Git Bash parsing."""
+    monkeypatch.setattr(setup_mod, "_is_windows", lambda: True)
+    cmd = r"C:\missing\python.exe -m claude_statusbar.cli render --flag"
+    assert setup_mod._repair_command(cmd) == \
+        "C:/missing/python.exe -m claude_statusbar.cli render --flag"
+
+
 # ---------------------------------------------------------------------------
 # explicit setup still force-writes the canonical form
 # ---------------------------------------------------------------------------

--- a/tests/test_setup_shell_path.py
+++ b/tests/test_setup_shell_path.py
@@ -1,0 +1,203 @@
+"""Windows shell-path handling in the statusLine config (issue #42).
+
+Claude Code executes the statusLine command string through a POSIX shell
+(Git Bash on Windows), where `\\` is an escape character:
+`C:\\Users\\me\\cs.EXE` execs as `C:Usersmecs.EXE` and dies with exit 127
+even though the file exists. The old daily self-heal then reverted any
+hand-fix, because it defined drift as "string differs from what I'd write
+today" and what it would write was the poisoned backslash path.
+
+These tests pin three behaviors:
+
+  1. paths are written with forward slashes, double-quoted when they contain
+     spaces (double quotes because cmd.exe has no single-quote semantics);
+  2. the daily self-heal repairs only *broken* entries — a working hand-fix
+     and user-added CLI flags are never churned;
+  3. a poisoned backslash entry is healed in place, argument tail intact.
+
+Backslash basename extraction goes through PureWindowsPath, so every case
+here also runs on POSIX CI.
+"""
+
+import json
+
+import pytest
+
+from claude_statusbar import setup as setup_mod
+
+
+def _bs(path) -> str:
+    """Backslash form of a real path — what shutil.which returns on Windows."""
+    return str(path).replace("/", "\\")
+
+
+@pytest.fixture
+def settings(monkeypatch, tmp_path):
+    p = tmp_path / ".claude" / "settings.json"
+    p.parent.mkdir(parents=True)
+    monkeypatch.setattr(setup_mod, "SETTINGS_PATH", p)
+    return p
+
+
+@pytest.fixture
+def cs_exe(tmp_path):
+    """A real file standing in for the installed cs.EXE."""
+    d = tmp_path / "Scripts"
+    d.mkdir()
+    exe = d / "cs.EXE"
+    exe.write_bytes(b"")
+    return exe
+
+
+# ---------------------------------------------------------------------------
+# _shell_path
+# ---------------------------------------------------------------------------
+def test_shell_path_posixizes_backslashes():
+    assert setup_mod._shell_path(r"C:\Users\me\Scripts\cs.EXE") == "C:/Users/me/Scripts/cs.EXE"
+
+
+def test_shell_path_double_quotes_spaces():
+    assert setup_mod._shell_path(r"C:\Users\First Last\Scripts\cs.EXE") == \
+        '"C:/Users/First Last/Scripts/cs.EXE"'
+
+
+def test_shell_path_leaves_posix_untouched():
+    assert setup_mod._shell_path("/usr/local/bin/cs") == "/usr/local/bin/cs"
+    assert setup_mod._shell_path("cs") == "cs"
+
+
+# ---------------------------------------------------------------------------
+# tokenization — must not eat backslashes the way shlex posix mode does
+# ---------------------------------------------------------------------------
+def test_command_tokens_preserve_backslashes():
+    assert setup_mod._command_tokens(r"C:\Users\me\cs.EXE render") == \
+        [r"C:\Users\me\cs.EXE", "render"]
+
+
+def test_command_tokens_strip_quotes():
+    assert setup_mod._command_tokens('"C:/Users/First Last/cs.EXE" render') == \
+        ["C:/Users/First Last/cs.EXE", "render"]
+
+
+def test_split_command_keeps_tail_verbatim():
+    tok0, tail = setup_mod._split_command(r"C:\x\cs.EXE --no-auto-update render")
+    assert tok0 == r"C:\x\cs.EXE"
+    assert tail == " --no-auto-update render"
+
+
+# ---------------------------------------------------------------------------
+# _is_our_statusline — poisoned entries must still read as ours (or the
+# heal would treat them as foreign and never fix them)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("cmd,expected", [
+    (r"C:\Users\foo\Scripts\cs.EXE", True),
+    (r"C:\Users\foo\Scripts\cs.EXE render", True),
+    ('"C:/Users/First Last/Scripts/cs.EXE" render', True),
+    (r"C:\tools\starship.exe", False),
+])
+def test_is_our_statusline_backslash_and_quoted(cmd, expected):
+    assert setup_mod._is_our_statusline({"type": "command", "command": cmd}) is expected
+
+
+# ---------------------------------------------------------------------------
+# fresh install writes a shell-safe command
+# ---------------------------------------------------------------------------
+def test_fresh_write_never_contains_backslashes(settings, monkeypatch):
+    monkeypatch.setattr(setup_mod, "_resolve_cs_command",
+                        lambda: r"C:\py\Scripts\cs.EXE")
+    changed, _ = setup_mod.ensure_statusline_configured()
+    assert changed is True
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert data["statusLine"]["command"] == "C:/py/Scripts/cs.EXE render"
+
+
+def test_fresh_write_quotes_spaced_path(settings, monkeypatch):
+    monkeypatch.setattr(setup_mod, "_resolve_cs_command",
+                        lambda: r"C:\Users\First Last\Scripts\cs.EXE")
+    setup_mod.ensure_statusline_configured()
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert data["statusLine"]["command"] == \
+        '"C:/Users/First Last/Scripts/cs.EXE" render'
+    # and the written entry must still be recognized as ours
+    assert setup_mod._is_our_statusline(data["statusLine"]) is True
+
+
+# ---------------------------------------------------------------------------
+# daily self-heal (fast=None): repair broken, never churn working
+# ---------------------------------------------------------------------------
+def test_hand_fix_survives_daily_pass(settings, cs_exe, monkeypatch):
+    """The issue #42 loop: forward-slash hand-fix must not be reverted even
+    though the resolver still reports the backslash form."""
+    hand_fix = cs_exe.as_posix() + " render"
+    settings.write_text(json.dumps({"statusLine": {
+        "type": "command", "command": hand_fix, "refreshInterval": 1}}),
+        encoding="utf-8")
+    monkeypatch.setattr(setup_mod, "_resolve_cs_command", lambda: _bs(cs_exe))
+    changed, msg = setup_mod.ensure_statusline_configured()
+    assert changed is False, f"daily pass churned a working entry: {msg}"
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert data["statusLine"]["command"] == hand_fix
+
+
+def test_backslash_entry_healed_in_place_args_survive(settings, cs_exe, monkeypatch):
+    """Poisoned entry → forward slashes, user flags untouched."""
+    settings.write_text(json.dumps({"statusLine": {
+        "type": "command",
+        "command": _bs(cs_exe) + " --no-auto-update",
+        "refreshInterval": 5}}), encoding="utf-8")
+    monkeypatch.setattr(setup_mod, "_is_windows", lambda: True)
+    changed, _ = setup_mod.ensure_statusline_configured()
+    assert changed is True
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert data["statusLine"]["command"] == cs_exe.as_posix() + " --no-auto-update"
+    assert data["statusLine"]["refreshInterval"] == 5
+
+
+def test_bare_name_upgraded_to_absolute_tail_preserved(settings, cs_exe, monkeypatch):
+    settings.write_text(json.dumps({"statusLine": {
+        "type": "command", "command": "cs render", "refreshInterval": 1}}),
+        encoding="utf-8")
+    monkeypatch.setattr(setup_mod, "_resolve_cs_command", lambda: _bs(cs_exe))
+    changed, _ = setup_mod.ensure_statusline_configured()
+    assert changed is True
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert data["statusLine"]["command"] == cs_exe.as_posix() + " render"
+
+
+def test_stale_path_replaced_tail_preserved(settings, monkeypatch):
+    settings.write_text(json.dumps({"statusLine": {
+        "type": "command", "command": "/old/missing/cs render",
+        "refreshInterval": 1}}), encoding="utf-8")
+    monkeypatch.setattr(setup_mod, "_resolve_cs_command", lambda: "/new/path/cs")
+    changed, _ = setup_mod.ensure_statusline_configured()
+    assert changed is True
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert data["statusLine"]["command"] == "/new/path/cs render"
+
+
+def test_module_form_untouched_by_daily_pass(settings, monkeypatch):
+    mod_cmd = "C:/py/python.exe -m claude_statusbar.cli render"
+    settings.write_text(json.dumps({"statusLine": {
+        "type": "command", "command": mod_cmd, "refreshInterval": 1}}),
+        encoding="utf-8")
+    changed, _ = setup_mod.ensure_statusline_configured()
+    assert changed is False
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert data["statusLine"]["command"] == mod_cmd
+
+
+# ---------------------------------------------------------------------------
+# explicit setup still force-writes the canonical form
+# ---------------------------------------------------------------------------
+def test_explicit_setup_still_force_writes(settings, cs_exe, monkeypatch):
+    """`cs --setup --fast` is an explicit request — canonical rewrite, custom
+    flags may drop. Only the *daily* pass is bound to preserve them."""
+    settings.write_text(json.dumps({"statusLine": {
+        "type": "command",
+        "command": cs_exe.as_posix() + " --no-auto-update",
+        "refreshInterval": 1}}), encoding="utf-8")
+    monkeypatch.setattr(setup_mod, "_resolve_cs_command", lambda: _bs(cs_exe))
+    changed, _ = setup_mod.ensure_statusline_configured(fast=True)
+    assert changed is True
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert data["statusLine"]["command"] == cs_exe.as_posix() + " render"


### PR DESCRIPTION
Fixes #42.

## What was happening

Claude Code executes the `statusLine` command through a POSIX shell (Git Bash on Windows), where `\` is an escape character:

```
$ sh -c 'C:\Users\me\.local\bin\cs.EXE'
sh: line 1: C:Usersme.localbincs.EXE: command not found   (exit 127)
```

`_resolve_cs_command()` returned `shutil.which()`'s backslash path verbatim, so on Windows the bar was shell-dead from the very first write. Worse, the daily self-heal defined drift as *"string differs from what I'd write today"* — and what it would write **was** the poisoned path — so any hand-fix was reverted within 24h, exactly as reported. I reproduced the full loop on Windows 11 + Git Bash.

Investigating turned up two more casualties of the same string-equality check:

- a working legacy bare-`cs` entry got rewritten into the broken absolute backslash path (the self-heal itself was the infection vector);
- user-added CLI flags (e.g. `--no-auto-update`) were silently stripped on every daily pass, while the module form and `refreshInterval` were deliberately preserved — inconsistent.

## The fix, three layers

**1. Write boundary** — paths are posix-ized before being written into `settings.json` (forward slashes are valid in sh *and* cmd.exe), and double-quoted when they contain spaces (`C:/Users/First Last/...`). Double quotes, not `shlex.quote`: cmd.exe has no single-quote semantics. Tokenization uses `shlex.split(posix=False)` + `PureWindowsPath` — posix mode eats backslashes, which would make a poisoned entry parse as *foreign* and exempt it from healing; `PureWindowsPath` makes basename extraction work on POSIX CI too.

**2. Repair semantics** — the daily pass (`fast=None`) now rewrites only *broken* entries:

- backslash executable on Windows — shell-dead even though `Path(...).is_file()` says healthy, so this check runs before any filesystem probe; healed **in place** to forward slashes,
- bare name → absolute upgrade (GUI-launched Claude Code PATH gaps — the feature's original purpose, kept),
- executable no longer exists → re-resolved.

Repairs replace only the executable token; the argument tail survives verbatim. A working hand-fix, the fast/inline choice, and custom flags are never churned. Explicit `cs --setup [--fast|--inline]` keeps its force-write behavior — that's a user request. Already-poisoned installs self-heal on their next daily tick, no manual action needed.

**3. Detection** — `cs doctor` gains a **statusLine shell test** that execs the *configured* command string through `sh` (the render smoke test builds its own argv, which is exactly why this class of breakage stayed invisible — same blind spot #36's fix closed for crashes). On Windows a backslash command is flagged statically:

```
✗ statusLine shell test  backslash path — Git Bash eats `\` before exec; run: cs --setup
```

## Tests

`tests/test_setup_shell_path.py` — 15 new tests: backslash/quoting fixtures the suite previously lacked (existing Windows tests only used forward-slash paths and never asserted on the written value), plus regression pins for "hand-fix survives the daily pass" and "args survive a heal". All run on POSIX CI via `PureWindowsPath`.

Full run on Windows 11: 77 passed; the 3 remaining failures in `test_setup.py` fail identically on a clean `upstream/main` checkout (POSIX-only assumptions: raw `cs.EXE` basename assert, chmod semantics) — pre-existing, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows `statusLine` path handling, including paths with spaces and backslashes.
  * Automatic repairs now preserve custom arguments, refresh intervals, and module-based commands.
  * Improved recovery for missing executables, outdated paths, and invalid refresh settings.

* **New Features**
  * Added `cs doctor` checks for status-line shell execution, blank output, and command failures.

* **Documentation**
  * Documented the Windows status-line fixes and self-healing improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->