### PR TITLE
fix(updater): uv/venv installs misread as shadow installs, blocking auto-upgrade

### DIFF
--- a/src/claude_statusbar/updater.py
+++ b/src/claude_statusbar/updater.py
@@ -223,11 +223,18 @@ def is_shadow_install() -> bool:
     entry = path_entrypoint()
     if entry is None:
         return False  # nothing on PATH to shadow
+    # Compare bin DIRECTORIES, resolving the directory rather than the
+    # interpreter file. In a uv-tool / venv install `bin/python3` is a symlink
+    # to the base interpreter (e.g. Homebrew's Cellar), so resolving the file
+    # lands outside the venv and every such install misreads as a shadow —
+    # auto-upgrade then never runs (observed: 3.13.6 stuck for 3 months with
+    # auto_upgrade on). The real shadow case — `cs` on PATH living in a
+    # different install's bin — still differs after this change.
     try:
-        here = Path(sys.executable).resolve()
+        here = Path(sys.executable).parent.resolve()
     except OSError:
         return False
-    return entry.parent != here.parent
+    return entry.parent != here
 
 
 def find_duplicate_installs() -> list:

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -402,3 +402,43 @@ def test_release_tag_strips_the_v_prefix(monkeypatch):
     monkeypatch.setattr(updater.urllib.request, "urlopen",
                         lambda req, timeout=None: _Resp())
     assert updater.latest_release_tag() == "3.40.0"
+
+
+def _fake_venv(tmp_path):
+    """A uv-tool-style venv: bin/python3 -> symlink to a base interpreter that
+    lives somewhere else entirely (Homebrew Cellar, pyenv, uv-managed CPython)."""
+    base = tmp_path / "Cellar" / "python@3.13" / "bin"
+    base.mkdir(parents=True)
+    (base / "python3.13").write_text("")
+    venv_bin = tmp_path / "uv" / "tools" / "claude-statusbar" / "bin"
+    venv_bin.mkdir(parents=True)
+    (venv_bin / "python3").symlink_to(base / "python3.13")
+    (venv_bin / "cs").write_text("")
+    return venv_bin
+
+
+def test_shadow_install_not_triggered_by_symlinked_venv_interpreter(monkeypatch, tmp_path):
+    # Regression: resolving sys.executable followed the venv's python3 symlink
+    # out to the base interpreter, so entry.parent never matched and every
+    # uv-tool install refused to auto-upgrade itself.
+    venv_bin = _fake_venv(tmp_path)
+    local_bin = tmp_path / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    (local_bin / "cs").symlink_to(venv_bin / "cs")   # uv's shared entry point
+    monkeypatch.setattr(updater.shutil, "which", lambda name: str(local_bin / "cs"))
+    monkeypatch.setattr(updater.sys, "executable", str(venv_bin / "python3"))
+
+    assert updater.is_shadow_install() is False
+
+
+def test_shadow_install_still_detects_foreign_entrypoint(monkeypatch, tmp_path):
+    # The case the guard exists for: `cs` on PATH is a different install
+    # (here a standalone binary), so this copy must not upgrade over it.
+    venv_bin = _fake_venv(tmp_path)
+    local_bin = tmp_path / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    (local_bin / "cs").write_text("")   # a real file, not a link into our venv
+    monkeypatch.setattr(updater.shutil, "which", lambda name: str(local_bin / "cs"))
+    monkeypatch.setattr(updater.sys, "executable", str(venv_bin / "python3"))
+
+    assert updater.is_shadow_install() is True


### PR DESCRIPTION
## Problem

`is_shadow_install()` resolves `sys.executable` and compares its parent directory with the resolved `cs` entry point's parent. In a `uv tool install` (or any venv) `bin/python3` is a symlink to the base interpreter, so the resolved path is e.g. `/opt/homebrew/Cellar/python@3.13/.../bin/python3.13` while `cs` resolves to `~/.local/share/uv/tools/claude-statusbar/bin/cs`. The parents never match, every uv install reads as a shadow, and `auto_upgrade()` returns False on every daily check.

Observed on macOS: a uv install stayed on 3.13.6 from June 11 to September 3 with `auto_upgrade = true`, while the bar showed `↑3.41.0` the whole time. `latest_version.json` was refreshed daily; the upgrade simply never ran.

Repro on any uv-tool install:

```
$ ~/.local/share/uv/tools/claude-statusbar/bin/python3 -c "from claude_statusbar import updater; print(updater.is_shadow_install())"
True
```

## Fix

Resolve the interpreter's **bin directory**, not the interpreter file. The directory is real, so it stays inside the venv; the file is a symlink out of it.

The case the guard was written for (a stale uv copy sitting behind a standalone binary, #47/#48 era) still trips: that `cs` resolves into a different directory than this install's `bin`.

## Tests

Two new tests build a fake uv venv (`bin/python3 -> ../Cellar/.../python3.13`) in `tmp_path`:

- entry point symlinked into our venv → not a shadow (fails on `main`, passes here)
- entry point a foreign file in `~/.local/bin` → still a shadow

Full suite: 1147 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwnDyXt3YcGyuhb3L5CfSt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shadow-install detection for virtual environments whose interpreters resolve to an external base interpreter.
  - Correctly distinguishes virtual-environment command links from separate, foreign installations.

- **Tests**
  - Added coverage for symlinked virtual-environment entry points and independently installed commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->